### PR TITLE
Rename to lexicon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 jobs:
-  blog-site-ci:
+  lexicon-ci:
     runs-on: ubuntu-latest
     # services:
     #   postgres:

--- a/apps/front-end/src/components/Editor.tsx
+++ b/apps/front-end/src/components/Editor.tsx
@@ -20,7 +20,7 @@ function Editor({ initialContent }: EditorProps) {
     <>
       <LexicalComposer
         initialConfig={{
-          namespace: "blog-editor",
+          namespace: "lexicon-editor",
           theme: {},
           editorState: (editor) => {
             if (initialContent) {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "blog-site",
+  "name": "lexicon",
   "private": true,
   "author": "alextheman",
-  "description": "The true successor to Neurosongs, allowing users to write blogs and share them, with a dynamic editor to help with in-line images/audio/files in general.",
+  "description": "The true successor to Neurosongs, allowing users to write blogs and share them, with a dynamic editor.",
   "type": "module",
   "scripts": {
     "build": "turbo run build",

--- a/turbo.json
+++ b/turbo.json
@@ -4,17 +4,13 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": [".next/**", "!.next/cache/**"]
+      "inputs": ["$TURBO_DEFAULT$", ".env*"]
     },
     "format": {
       "dependsOn": ["^format"]
     },
     "lint": {
       "dependsOn": ["^lint"]
-    },
-    "check-types": {
-      "dependsOn": ["^check-types"]
     },
     "dev": {
       "cache": false,


### PR DESCRIPTION
Unfortunately, Lexical is taken already, but Lexicon is close enough and also works fairly well.

# Documentation Change

This is a change to the documentation of `blog-site`. It changes the way that information about the app is presented to users.

Please see the commits tab of this pull request for the description of changes.
