### PR TITLE
Add dist to build output

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,8 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "inputs": ["$TURBO_DEFAULT$", ".env*"]
+      "inputs": ["$TURBO_DEFAULT$", ".env*"],
+      "outputs": ["dist/**"]
     },
     "format": {
       "dependsOn": ["^format"]


### PR DESCRIPTION
This ensures that if build gets cached, so do the built outputs.

# Tooling Change

This is a change to the tooling of `blog-site`. It changes the internal workings of the app and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
