### PR TITLE
Correct the condition

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   update-dependencies:
-    if: ${{ github.repository == 'alextheman231/blog-site' }}
+    if: ${{ github.repository == 'alextheman231/lexicon' }}
     uses: alextheman231/github-actions/.github/workflows/update-dependencies.yml@dc2d1246a158a1a04045a85a8c1bfd1978afeaf2 # v10.1.0
     secrets:
       APP_ID: ${{ secrets.ALEX_UP_BOT_APP_ID }}


### PR DESCRIPTION
The repository name is now Lexicon given we have now decided the name.

Really, though, the fact that the workflow can't itself just say 'only run the workflow is the repository is the original repository' rather than make me do the manual comparison is such an oversight and so annoying!