### PR TITLE
Remove all references to @lexicon/schema

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/breaking_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/breaking_change.md
@@ -1,5 +1,5 @@
 # Breaking Change
 
-This is a change to `blog-site` that will cause breaking changes in how the app is used and/or deployed.
+This is a change to `lexicon` that will cause breaking changes in how the app is used and/or deployed.
 
 Please see the commits tab of this pull request for the description of changes.

--- a/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
@@ -1,5 +1,5 @@
 # Bug Fix
 
-This is a bug fix for `blog-site`. It fixes an unintended side-effect of the app.
+This is a bug fix for `lexicon`. It fixes an unintended side-effect of the app.
 
 Please see the commits tab of this pull request for the description of changes.

--- a/.github/PULL_REQUEST_TEMPLATE/documentation_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/documentation_change.md
@@ -1,5 +1,5 @@
 # Documentation Change
 
-This is a change to the documentation of `blog-site`. It changes the way that information about the app is presented to users.
+This is a change to the documentation of `lexicon`. It changes the way that information about the app is presented to users.
 
 Please see the commits tab of this pull request for the description of changes.

--- a/.github/PULL_REQUEST_TEMPLATE/internal_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/internal_change.md
@@ -1,5 +1,5 @@
 # Internal Change
 
-This is a change to the internal features of `blog-site`. It changes features of the app that are exposed through some internal group on the public surface but are not recommended for public usage.
+This is a change to the internal features of `lexicon`. It changes features of the app that are exposed through some internal group on the public surface but are not recommended for public usage.
 
 Please see the commits tab of this pull request for the description of changes.

--- a/.github/PULL_REQUEST_TEMPLATE/miscellaneous.md
+++ b/.github/PULL_REQUEST_TEMPLATE/miscellaneous.md
@@ -1,5 +1,5 @@
 # Miscellaneous
 
-This is a general change to `blog-site` that does not fit in any of the other provided categories.
+This is a general change to `lexicon` that does not fit in any of the other provided categories.
 
 Please see the commits tab of this pull request for the description of changes.

--- a/.github/PULL_REQUEST_TEMPLATE/new_feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new_feature.md
@@ -1,5 +1,5 @@
 # New Feature
 
-This is a new feature for `blog-site`. It adds new functionality to the app.
+This is a new feature for `lexicon`. It adds new functionality to the app.
 
 Please see the commits tab of this pull request for the description of changes.

--- a/.github/PULL_REQUEST_TEMPLATE/refactor.md
+++ b/.github/PULL_REQUEST_TEMPLATE/refactor.md
@@ -1,5 +1,5 @@
 # Refactor
 
-This is a change to the code layout of `blog-site`. It changes how the code is presented in terms of quality and structure without changing its overall user-facing behaviour or functionality.
+This is a change to the code layout of `lexicon`. It changes how the code is presented in terms of quality and structure without changing its overall user-facing behaviour or functionality.
 
 Please see the commits tab of this pull request for the description of changes.

--- a/.github/PULL_REQUEST_TEMPLATE/tooling_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/tooling_change.md
@@ -1,5 +1,5 @@
 # Tooling Change
 
-This is a change to the tooling of `blog-site`. It changes the internal workings of the app and should have no noticeable effect on users.
+This is a change to the tooling of `lexicon`. It changes the internal workings of the app and should have no noticeable effect on users.
 
 Please see the commits tab of this pull request for the description of changes.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,8 @@
 # Select a Template
 
-Please select the option that best describes your changes to `blog-site`:
+Please select the option that best describes your changes to `lexicon`:
 
-- [Breaking Change](?template=breaking_change.md) - may require changes in how the app is used and/or deployed.
+- [Breaking Change](?template=breaking_change.md) - For changes that have a substantial effect on how the app is used and/or deployed.
 - [New Feature](?template=new_feature.md) - For changes that add a new feature to the app.
 - [Bug Fix](?template=bug_fix.md) - For changes that fix a bug in the app.
 - [Tooling Change](?template=tooling_change.md) - For changes to the app's tooling (dependencies, devDependencies, configs...).

--- a/apps/back-end/package.json
+++ b/apps/back-end/package.json
@@ -27,7 +27,8 @@
     "start-test-db": "docker compose -f docker-compose.test.yml up -d && cross-env NODE_ENV=test pnpm run migrate-db",
     "test": "vitest --run",
     "test-debug": "cross-env DEBUG=true pnpm test",
-    "test-watch": "vitest"
+    "test-watch": "vitest",
+    "update-dependencies": "pnpm update --latest && pnpm update"
   },
   "author": "alextheman",
   "license": "ISC",

--- a/apps/front-end/package.json
+++ b/apps/front-end/package.json
@@ -18,7 +18,8 @@
     "lint-prettier-javascript": "prettier --check \"./**/*.js\"",
     "lint-prettier-typescript": "prettier --check --parser typescript \"./**/*.{ts,tsx}\"",
     "lint-tsc": "tsc --noEmit",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "update-dependencies": "pnpm update --latest && pnpm update"
   },
   "dependencies": {
     "react": "^19.2.4",

--- a/package.json
+++ b/package.json
@@ -19,11 +19,12 @@
     "pre-commit": "alex-c-line pre-commit",
     "prepare": "husky",
     "test": "turbo run test",
-    "update-dependencies": "pnpm update --latest && pnpm update"
+    "update-dependencies": "turbo run update-dependencies && pnpm update --latest && pnpm update"
   },
   "devDependencies": {
     "@alextheman/eslint-plugin": "^5.10.1",
     "@faker-js/faker": "^10.3.0",
+    "@typescript-eslint/utils": "^8.57.0",
     "alex-c-line": "^2.0.1",
     "cross-env": "^10.1.0",
     "eslint": "^10.0.2",

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -22,7 +22,8 @@
     "lint-prettier": "pnpm run lint-prettier-typescript && pnpm run lint-prettier-javascript",
     "lint-prettier-javascript": "prettier --check \"./**/*.js\"",
     "lint-prettier-typescript": "prettier --check --parser typescript \"./**/*.{ts,tsx}\"",
-    "lint-tsc": "tsc --noEmit"
+    "lint-tsc": "tsc --noEmit",
+    "update-dependencies": "pnpm update --latest && pnpm update"
   },
   "author": "alextheman",
   "license": "ISC",

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -27,7 +27,6 @@
   "author": "alextheman",
   "license": "ISC",
   "dependencies": {
-    "@lexicon/schema": "workspace:*",
     "lexical": "^0.41.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,9 +154,6 @@ importers:
 
   packages/models:
     dependencies:
-      '@lexicon/schema':
-        specifier: workspace:*
-        version: link:../schema
       lexical:
         specifier: ^0.41.0
         version: 0.41.0
@@ -164,25 +161,6 @@ importers:
       '@types/node':
         specifier: ^25.2.3
         version: 25.2.3
-
-  packages/schema:
-    dependencies:
-      lexical:
-        specifier: ^0.41.0
-        version: 0.41.0
-      pg:
-        specifier: ^8.20.0
-        version: 8.20.0
-    devDependencies:
-      '@types/node':
-        specifier: ^25.2.3
-        version: 25.2.3
-      drizzle-orm:
-        specifier: ^0.45.1
-        version: 0.45.1(@types/pg@8.18.0)(pg@8.20.0)
-      tsdown:
-        specifier: ^0.21.0
-        version: 0.21.0(synckit@0.11.12)(typescript@5.9.3)
 
 packages:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@faker-js/faker':
         specifier: ^10.3.0
         version: 10.3.0
+      '@typescript-eslint/utils':
+        specifier: ^8.57.0
+        version: 8.57.0(eslint@10.0.2)(typescript@5.9.3)
       alex-c-line:
         specifier: ^2.0.1
         version: 2.0.1(@types/node@25.2.3)
@@ -1558,12 +1561,28 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/project-service@8.57.0':
+    resolution: {integrity: sha512-pR+dK0BlxCLxtWfaKQWtYr7MhKmzqZxuii+ZjuFlZlIGRZm22HnXFqa2eY+90MUz8/i80YJmzFGDUsi8dMOV5w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/scope-manager@8.56.1':
     resolution: {integrity: sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/scope-manager@8.57.0':
+    resolution: {integrity: sha512-nvExQqAHF01lUM66MskSaZulpPL5pgy5hI5RfrxviLgzZVffB5yYzw27uK/ft8QnKXI2X0LBrHJFr1TaZtAibw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/tsconfig-utils@8.56.1':
     resolution: {integrity: sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/tsconfig-utils@8.57.0':
+    resolution: {integrity: sha512-LtXRihc5ytjJIQEH+xqjB0+YgsV4/tW35XKX3GTZHpWtcC8SPkT/d4tqdf1cKtesryHm2bgp6l555NYcT2NLvA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
@@ -1579,8 +1598,18 @@ packages:
     resolution: {integrity: sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/types@8.57.0':
+    resolution: {integrity: sha512-dTLI8PEXhjUC7B9Kre+u0XznO696BhXcTlOn0/6kf1fHaQW8+VjJAVHJ3eTI14ZapTxdkOmc80HblPQLaEeJdg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/typescript-estree@8.56.1':
     resolution: {integrity: sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/typescript-estree@8.57.0':
+    resolution: {integrity: sha512-m7faHcyVg0BT3VdYTlX8GdJEM7COexXxS6KqGopxdtkQRvBanK377QDHr4W/vIPAR+ah9+B/RclSW5ldVniO1Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
@@ -1592,8 +1621,19 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/utils@8.57.0':
+    resolution: {integrity: sha512-5iIHvpD3CZe06riAsbNxxreP+MuYgVUsV0n4bwLH//VJmgtt54sQeY2GszntJ4BjYCpMzrfVh2SBnUQTtys2lQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/visitor-keys@8.56.1':
     resolution: {integrity: sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.57.0':
+    resolution: {integrity: sha512-zm6xx8UT/Xy2oSr2ZXD0pZo7Jx2XsCoID2IUh9YSTFRu7z+WdwYTRk6LhUftm1crwqbuoF6I8zAFeCMw0YjwDg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
@@ -4311,7 +4351,7 @@ snapshots:
       '@eslint/compat': 2.0.2(eslint@10.0.2)
       '@eslint/js': 9.39.2
       '@typescript-eslint/types': 8.56.1
-      '@typescript-eslint/utils': 8.56.1(eslint@10.0.2)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.57.0(eslint@10.0.2)(typescript@5.9.3)
       common-tags: 1.8.2
       eslint: 10.0.2
       eslint-config-prettier: 10.1.1(eslint@10.0.2)
@@ -5530,12 +5570,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/project-service@8.57.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.57.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.57.0
+      debug: 4.4.3(supports-color@5.5.0)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/scope-manager@8.56.1':
     dependencies:
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/visitor-keys': 8.56.1
 
+  '@typescript-eslint/scope-manager@8.57.0':
+    dependencies:
+      '@typescript-eslint/types': 8.57.0
+      '@typescript-eslint/visitor-keys': 8.57.0
+
   '@typescript-eslint/tsconfig-utils@8.56.1(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@typescript-eslint/tsconfig-utils@8.57.0(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
@@ -5553,12 +5611,29 @@ snapshots:
 
   '@typescript-eslint/types@8.56.1': {}
 
+  '@typescript-eslint/types@8.57.0': {}
+
   '@typescript-eslint/typescript-estree@8.56.1(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/project-service': 8.56.1(typescript@5.9.3)
       '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/visitor-keys': 8.56.1
+      debug: 4.4.3(supports-color@5.5.0)
+      minimatch: 10.2.4
+      semver: 7.7.4
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.4.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.57.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.57.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.57.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.57.0
+      '@typescript-eslint/visitor-keys': 8.57.0
       debug: 4.4.3(supports-color@5.5.0)
       minimatch: 10.2.4
       semver: 7.7.4
@@ -5579,9 +5654,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@8.57.0(eslint@10.0.2)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.2)
+      '@typescript-eslint/scope-manager': 8.57.0
+      '@typescript-eslint/types': 8.57.0
+      '@typescript-eslint/typescript-estree': 8.57.0(typescript@5.9.3)
+      eslint: 10.0.2
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/visitor-keys@8.56.1':
     dependencies:
       '@typescript-eslint/types': 8.56.1
+      eslint-visitor-keys: 5.0.1
+
+  '@typescript-eslint/visitor-keys@8.57.0':
+    dependencies:
+      '@typescript-eslint/types': 8.57.0
       eslint-visitor-keys: 5.0.1
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@lexicon/schema": ["packages/schema/src"],
       "@lexicon/models": ["packages/models/src"]
     }
   }

--- a/turbo.json
+++ b/turbo.json
@@ -11,10 +11,10 @@
       "dependsOn": ["^format"]
     },
     "lint": {
-      "dependsOn": ["^lint"]
+      "dependsOn": []
     },
     "test": {
-      "dependsOn": ["^test"]
+      "dependsOn": []
     },
     "dev": {
       "cache": false,

--- a/turbo.json
+++ b/turbo.json
@@ -19,6 +19,9 @@
     "dev": {
       "cache": false,
       "persistent": true
+    },
+    "update-dependencies": {
+      "dependsOn": ["^update-dependencies"]
     }
   }
 }


### PR DESCRIPTION
It is no longer a package in this monorepo as it has recently been moved purely to the back-end part of the repository.

# Tooling Change

This is a change to the tooling of `blog-site`. It changes the internal workings of the app and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
