### PR TITLE
Disable verbatimModuleSyntax and allowTsExtensionImports

### DIFF
--- a/apps/front-end/tsconfig.app.json
+++ b/apps/front-end/tsconfig.app.json
@@ -13,8 +13,6 @@
 
     /* Bundler mode */
     "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
-    "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",

--- a/apps/front-end/tsconfig.node.json
+++ b/apps/front-end/tsconfig.node.json
@@ -12,8 +12,6 @@
 
     /* Bundler mode */
     "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
-    "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,
 


### PR DESCRIPTION
verbatimModuleSyntax is already covered by ESLint in a rule that is also fixable, and I don't want to allow .ts extensions in import statements as they are not needed.

# Tooling Change

This is a change to the tooling of `lexicon`. It changes the internal workings of the app and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
