### PR TITLE
Implement new error handling pattern front-end

### DIFF
--- a/apps/front-end/src/components/ErrorMessage.tsx
+++ b/apps/front-end/src/components/ErrorMessage.tsx
@@ -1,0 +1,17 @@
+import type { CodeErrorMap } from "src/utility/errors/errorFormatters";
+
+import Alert from "@mui/material/Alert";
+
+import formatError from "src/utility/errors/formatError";
+
+interface ErrorMessageProps {
+  error: unknown;
+  codeErrorMap?: CodeErrorMap;
+  errorFunction?: (error: unknown) => string;
+}
+
+function ErrorMessage({ error, codeErrorMap, errorFunction }: ErrorMessageProps) {
+  return <Alert severity="error">{formatError(error, codeErrorMap, errorFunction)}</Alert>;
+}
+
+export default ErrorMessage;

--- a/apps/front-end/src/components/QueryBoundary.tsx
+++ b/apps/front-end/src/components/QueryBoundary.tsx
@@ -1,0 +1,37 @@
+import type { QueryBoundaryDataProps, QueryBoundaryErrorProps } from "@alextheman/components";
+
+import type { QueryBoundaryProviderProps } from "src/components/QueryBoundaryProvider";
+
+import { QueryBoundary as AlexQueryBoundary } from "@alextheman/components";
+
+import ErrorMessage from "src/components/ErrorMessage";
+
+export type QueryBoundaryProps<DataType> = Omit<
+  QueryBoundaryProviderProps<DataType>,
+  "children" | "logError"
+> &
+  Omit<QueryBoundaryErrorProps, "children"> &
+  Omit<QueryBoundaryDataProps<DataType>, "showOnError">;
+
+function QueryBoundary<DataType>({
+  children,
+  codeErrorMap,
+  errorFunction,
+  ...queryBoundaryProps
+}: QueryBoundaryProps<DataType>) {
+  return (
+    <AlexQueryBoundary
+      logError={import.meta.env.DEV}
+      errorComponent={(error) => {
+        return (
+          <ErrorMessage error={error} codeErrorMap={codeErrorMap} errorFunction={errorFunction} />
+        );
+      }}
+      {...queryBoundaryProps}
+    >
+      {children}
+    </AlexQueryBoundary>
+  );
+}
+
+export default QueryBoundary;

--- a/apps/front-end/src/components/QueryBoundaryProvider.tsx
+++ b/apps/front-end/src/components/QueryBoundaryProvider.tsx
@@ -1,0 +1,65 @@
+import type {
+  QueryBoundaryProviderPropsWithError as AlexQueryBoundaryProviderPropsWithError,
+  QueryBoundaryProviderPropsWithNoError as AlexQueryBoundaryProviderPropsWithNoError,
+} from "@alextheman/components";
+import type { ReactNode } from "react";
+
+import type { CodeErrorMap } from "src/utility/errors/errorFormatters";
+
+import { QueryBoundaryProvider as AlexQueryBoundaryProvider } from "@alextheman/components";
+
+import ErrorMessage from "src/components/ErrorMessage";
+
+export interface QueryBoundaryProviderPropsWithError<
+  DataType,
+> extends AlexQueryBoundaryProviderPropsWithError<DataType> {
+  codeErrorMap?: never;
+  errorFunction?: never;
+}
+
+export interface QueryBoundaryProviderPropsWithNoError<
+  DataType,
+> extends AlexQueryBoundaryProviderPropsWithNoError<DataType> {
+  codeErrorMap?: never;
+  errorFunction?: never;
+}
+
+export interface QueryBoundaryProviderPropsWithCodeError<DataType> extends Omit<
+  AlexQueryBoundaryProviderPropsWithError<DataType>,
+  "errorComponent"
+> {
+  errorComponent?: never;
+  codeErrorMap?: CodeErrorMap;
+  errorFunction?: (error: unknown) => string;
+}
+
+export type QueryBoundaryProviderProps<DataType> = (
+  | QueryBoundaryProviderPropsWithError<DataType>
+  | QueryBoundaryProviderPropsWithCodeError<DataType>
+  | QueryBoundaryProviderPropsWithNoError<DataType>
+) & {
+  children: ReactNode;
+};
+
+function QueryBoundaryProvider<DataType>({
+  codeErrorMap,
+  errorFunction,
+  children,
+  ...queryBoundaryProviderProps
+}: QueryBoundaryProviderProps<DataType>) {
+  return (
+    <AlexQueryBoundaryProvider
+      logError={import.meta.env.DEV}
+      errorComponent={(error) => {
+        return (
+          <ErrorMessage error={error} codeErrorMap={codeErrorMap} errorFunction={errorFunction} />
+        );
+      }}
+      {...queryBoundaryProviderProps}
+    >
+      {children}
+    </AlexQueryBoundaryProvider>
+  );
+}
+
+export default QueryBoundaryProvider;

--- a/apps/front-end/src/components/UserDropdown.tsx
+++ b/apps/front-end/src/components/UserDropdown.tsx
@@ -1,4 +1,4 @@
-import { ExternalLink, QueryBoundary } from "@alextheman/components";
+import { ExternalLink } from "@alextheman/components";
 import {
   DropdownMenu,
   DropdownMenuItem,
@@ -9,6 +9,7 @@ import {
 import Button from "@mui/material/Button";
 
 import { useAuth } from "src/AuthContextProvider";
+import QueryBoundary from "src/components/QueryBoundary";
 
 function UserDropdown() {
   const { currentUser, currentUserLoading, unauthenticate } = useAuth();

--- a/apps/front-end/src/resources/Users/pages/EditUserProfile.tsx
+++ b/apps/front-end/src/resources/Users/pages/EditUserProfile.tsx
@@ -1,9 +1,10 @@
 import type { UserProfileFormOutputData } from "@lexicon/models";
 
-import { Page, QueryBoundary } from "@alextheman/components";
+import { Page } from "@alextheman/components";
 import { useLocation } from "wouter";
 
 import { useAuth } from "src/AuthContextProvider";
+import QueryBoundary from "src/components/QueryBoundary";
 import UserProfileForm from "src/components/UserProfileForm";
 import { useUpdateUserProfileMutation } from "src/resources/Users/queries";
 

--- a/apps/front-end/src/resources/Users/pages/UserProfile.tsx
+++ b/apps/front-end/src/resources/Users/pages/UserProfile.tsx
@@ -1,9 +1,10 @@
-import { Page, QueryBoundary } from "@alextheman/components";
+import { Page } from "@alextheman/components";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import CardHeader from "@mui/material/CardHeader";
 import Divider from "@mui/material/Divider";
 
+import QueryBoundary from "src/components/QueryBoundary";
 import { useUserQuery } from "src/resources/Users/queries";
 
 interface UserProfileProps {

--- a/apps/front-end/src/utility/errors/errorFormatters.ts
+++ b/apps/front-end/src/utility/errors/errorFormatters.ts
@@ -1,0 +1,20 @@
+import type { CodeError } from "@alextheman/utility/v6";
+
+import { DataError } from "@alextheman/utility/v6";
+
+export type CodeErrorFormatter =
+  | string
+  | ((error: CodeError | DataError, status?: number) => string);
+export type CodeErrorMap = Record<string, CodeErrorFormatter>;
+
+const defaultErrorFormatters: CodeErrorMap = {
+  RESOURCE_NOT_FOUND: (error) => {
+    if (DataError.checkWithCode(error, "RESOURCE_NOT_FOUND")) {
+      const resourceType = error.data.resourceType ?? "resource";
+      return `The ${resourceType} you are looking for does not seem to exist.`;
+    }
+    return "The resource you are looking for does not seem to exist.";
+  },
+};
+
+export default defaultErrorFormatters;

--- a/apps/front-end/src/utility/errors/formatError.ts
+++ b/apps/front-end/src/utility/errors/formatError.ts
@@ -1,0 +1,56 @@
+import type { CodeErrorMap } from "src/utility/errors/errorFormatters";
+
+import { CodeError } from "@alextheman/utility/v6";
+import axios from "axios";
+
+import defaultErrorFormatters from "src/utility/errors/errorFormatters";
+
+const DEFAULT_MESSAGE = "Something went wrong. Please try again later.";
+
+function resolveErrorFromCode(error: CodeError, errorFormatters: CodeErrorMap, status?: number) {
+  if (error.code in errorFormatters) {
+    const defaultMessageForCode = errorFormatters[error.code];
+    if (typeof defaultMessageForCode === "function") {
+      return defaultMessageForCode(error, status);
+    }
+    return defaultMessageForCode;
+  }
+  return error.message ?? DEFAULT_MESSAGE;
+}
+
+function resolveError(
+  error: unknown,
+  codeErrorMap: CodeErrorMap,
+  errorFunction?: (error: unknown) => string,
+): string {
+  if (CodeError.check(error)) {
+    return resolveErrorFromCode(error, codeErrorMap);
+  }
+
+  if (errorFunction) {
+    return errorFunction(error);
+  }
+
+  return DEFAULT_MESSAGE;
+}
+
+function formatError(
+  error: unknown,
+  codeErrorMap: CodeErrorMap = defaultErrorFormatters,
+  errorFunction?: (error: unknown) => string,
+): string {
+  if (axios.isAxiosError(error)) {
+    const apiError =
+      error.response?.data && typeof error.response.data === "object"
+        ? error.response.data?.error
+        : undefined;
+
+    if (CodeError.check(apiError)) {
+      return resolveErrorFromCode(apiError, codeErrorMap, error.response?.status);
+    }
+    return resolveError(error, codeErrorMap, errorFunction);
+  }
+  return resolveError(error, codeErrorMap, errorFunction);
+}
+
+export default formatError;


### PR DESCRIPTION
The front-end goes by the assumption that errors thrown by the API will look close enough to a CodeError or DataError (CodeError.check() should cover both given inheritance). It will then map the code from the error to either a string or a function that takes the error and returns the string. If it's not a CodeError, however, the third argument of the errorFunction is called instead, and that can be used to deal with things like regular errors, for example. If all else fails, a default error message is shown instead.

Note that even though the back-end does actually also send the message too, I decided we can still have this message mapping if we frame it that the back-end error messages should make sense in the context of a user using the API, whereas the front-end messages should make sense for a casual user using Lexicon. In that sense the back-end is allowed to give more technical detail in its error message, whereas the front-end should not use too much technical language.

# New Feature

This is a new feature for `lexicon`. It adds new functionality to the app.

Please see the commits tab of this pull request for the description of changes.
