### PR TITLE
Add a QueryBoundaryDataMap wrapper that defaults to the provided ID i…

### DIFF
--- a/apps/front-end/package.json
+++ b/apps/front-end/package.json
@@ -22,7 +22,7 @@
     "update-dependencies": "pnpm update --latest && pnpm update"
   },
   "dependencies": {
-    "@alextheman/components": "6.15.4",
+    "@alextheman/components": "6.15.6",
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.1",
     "@lexicon/models": "workspace:*",

--- a/apps/front-end/src/components/QueryBoundaryDataMap.tsx
+++ b/apps/front-end/src/components/QueryBoundaryDataMap.tsx
@@ -1,0 +1,30 @@
+import type { QueryBoundaryDataMapProps } from "@alextheman/components";
+
+import { QueryBoundaryDataMap as AlexQueryBoundaryDataMap } from "@alextheman/components";
+
+function QueryBoundaryDataMap<ItemType>({
+  itemKey,
+  children,
+  ...props
+}: QueryBoundaryDataMapProps<ItemType>) {
+  return (
+    <AlexQueryBoundaryDataMap
+      {...props}
+      itemKey={
+        itemKey ??
+        ((item, index) => {
+          return typeof item === "object" &&
+            item !== null &&
+            "id" in item &&
+            (typeof item.id === "string" || typeof item.id === "number")
+            ? item.id
+            : index;
+        })
+      }
+    >
+      {children}
+    </AlexQueryBoundaryDataMap>
+  );
+}
+
+export default QueryBoundaryDataMap;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,8 +136,8 @@ importers:
   apps/front-end:
     dependencies:
       '@alextheman/components':
-        specifier: 6.15.4
-        version: 6.15.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@mui/material@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@tanstack/react-form@1.29.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-hook-form@7.72.1(react@19.2.5))(react-router-dom@7.14.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(wouter@3.9.0(react@19.2.5))
+        specifier: 6.15.6
+        version: 6.15.6(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@mui/material@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@tanstack/react-form@1.29.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-hook-form@7.72.1(react@19.2.5))(react-router-dom@7.14.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(wouter@3.9.0(react@19.2.5))
       '@emotion/react':
         specifier: 11.14.0
         version: 11.14.0(@types/react@19.2.14)(react@19.2.5)
@@ -206,8 +206,8 @@ packages:
   '@acemir/cssom@0.9.31':
     resolution: {integrity: sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==}
 
-  '@alextheman/components@6.15.4':
-    resolution: {integrity: sha512-+0BPcIw03dnVYer6RncdoBlxSh8duf8VhE0epvCRan9g8D3SZ1ggcQJCBXEAVJYLBXgkh10lwc9gz4XUjokBPw==}
+  '@alextheman/components@6.15.6':
+    resolution: {integrity: sha512-C5FwMPAoPZfPCRBx3XV6CdZJJ+soDnXIk7UAWTysVbJY4ex/uv4rofeFt67H4ZbyHeXZoFcl5pNOyhya7oYKDA==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       '@emotion/react': '>=11.0.0'
@@ -1723,6 +1723,10 @@ packages:
 
   '@typescript-eslint/types@8.59.0':
     resolution: {integrity: sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/types@8.59.1':
+    resolution: {integrity: sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@8.58.2':
@@ -4821,7 +4825,7 @@ snapshots:
   '@acemir/cssom@0.9.31':
     optional: true
 
-  '@alextheman/components@6.15.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@mui/material@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@tanstack/react-form@1.29.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-hook-form@7.72.1(react@19.2.5))(react-router-dom@7.14.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(wouter@3.9.0(react@19.2.5))':
+  '@alextheman/components@6.15.6(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@mui/material@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@tanstack/react-form@1.29.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-hook-form@7.72.1(react@19.2.5))(react-router-dom@7.14.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(wouter@3.9.0(react@19.2.5))':
     dependencies:
       '@alextheman/utility': 5.14.0
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.5)
@@ -5176,7 +5180,7 @@ snapshots:
   '@es-joy/jsdoccomment@0.79.0':
     dependencies:
       '@types/estree': 1.0.8
-      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/types': 8.59.1
       comment-parser: 1.4.1
       esquery: 1.7.0
       jsdoc-type-pratt-parser: 7.0.0
@@ -6227,6 +6231,8 @@ snapshots:
 
   '@typescript-eslint/types@8.59.0': {}
 
+  '@typescript-eslint/types@8.59.1': {}
+
   '@typescript-eslint/typescript-estree@8.58.2(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/project-service': 8.58.2(typescript@6.0.3)
@@ -7230,7 +7236,7 @@ snapshots:
   eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.0(eslint@10.2.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@10.2.1):
     dependencies:
       '@package-json/types': 0.0.12
-      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/types': 8.59.1
       comment-parser: 1.4.6
       debug: 4.4.3(supports-color@5.5.0)
       eslint: 10.2.1


### PR DESCRIPTION
…f present and is the correct type

This makes usage at the call site a little nicer so that we always try and use the ID as the key wherever we can, but if not we fall back to the index or use the user-defined itemKey.

# New Feature

This is a new feature for `lexicon`. It adds new functionality to the app.

Please see the commits tab of this pull request for the description of changes.
