### PR TITLE
Cache all .turbo folders in all workspaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,11 @@ jobs:
       - name: Cache Turborepo cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          path: .turbo
+          path: |
+            .turbo
+            apps/back-end/.turbo
+            apps/front-end/.turbo
+            packages/models/.turbo
           key: turbo-${{ hashFiles('{apps,packages}/**', 'package.json', 'pnpm-lock.yaml', 'pnpm-workspace.yaml', 'turbo.json') }}
           restore-keys: turbo-
 


### PR DESCRIPTION
I think previously we were just caching the root .turbo. This should change that so that we cache all of them, therefore potentially meaning more cache fits in CI potentially.

# Tooling Change

This is a change to the tooling of `lexicon`. It changes the internal workings of the app and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
