### PR TITLE
Make the ContentEditable more integrated with Material UI

### DIFF
--- a/apps/front-end/src/Router.tsx
+++ b/apps/front-end/src/Router.tsx
@@ -1,9 +1,10 @@
 import { Router as AlexRouter, Switch } from "@alextheman/components/v7";
 import { Route } from "wouter";
 
-import Editor from "src/components/Editor";
 import PageWrapper from "src/components/PageWrapper";
 import AuthCallback from "src/pages/AuthCallback";
+import BlogEditor from "src/resources/Blogs/components/BlogEditor";
+import BlogsRouter from "src/resources/Blogs/Router";
 import EditUserProfile from "src/resources/Users/pages/EditUserProfile";
 import UsersRouter from "src/resources/Users/Router";
 
@@ -13,7 +14,7 @@ function Router() {
       <PageWrapper>
         <Switch>
           <Route path="/">
-            <Editor />
+            <BlogEditor />
           </Route>
           <Route path="/auth/callback">
             <AuthCallback />
@@ -23,6 +24,9 @@ function Router() {
           </Route>
           <Route path="/users" nest>
             <UsersRouter />
+          </Route>
+          <Route path="/blogs" nest>
+            <BlogsRouter />
           </Route>
         </Switch>
       </PageWrapper>

--- a/apps/front-end/src/index.css
+++ b/apps/front-end/src/index.css
@@ -1,0 +1,15 @@
+.editor-input {
+  width: 100%;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+
+.editor-input p {
+  margin: 0;
+}
+
+.editor-input * {
+  white-space: inherit;
+  word-break: inherit;
+}

--- a/apps/front-end/src/resources/Blogs/Router.tsx
+++ b/apps/front-end/src/resources/Blogs/Router.tsx
@@ -1,0 +1,16 @@
+import { Switch } from "@alextheman/components/v7";
+import { Route } from "wouter";
+
+import CreateBlog from "src/resources/Blogs/pages/CreateBlog";
+
+function BlogsRouter() {
+  return (
+    <Switch>
+      <Route path="/new">
+        <CreateBlog />
+      </Route>
+    </Switch>
+  );
+}
+
+export default BlogsRouter;

--- a/apps/front-end/src/resources/Blogs/components/BlogEditor.tsx
+++ b/apps/front-end/src/resources/Blogs/components/BlogEditor.tsx
@@ -2,18 +2,20 @@ import type { SerializedEditorState } from "lexical";
 
 import { DataError } from "@alextheman/utility/v6";
 import { LexicalComposer } from "@lexical/react/LexicalComposer";
-import { ContentEditable } from "@lexical/react/LexicalContentEditable";
 import { LexicalErrorBoundary } from "@lexical/react/LexicalErrorBoundary";
 import { HistoryPlugin } from "@lexical/react/LexicalHistoryPlugin";
 import { OnChangePlugin } from "@lexical/react/LexicalOnChangePlugin";
 import { RichTextPlugin } from "@lexical/react/LexicalRichTextPlugin";
+import Box from "@mui/material/Box";
 import { useState } from "react";
+
+import ContentEditable from "src/resources/Blogs/components/ContentEditable";
 
 interface EditorProps {
   initialContent?: SerializedEditorState;
 }
 
-function Editor({ initialContent }: EditorProps) {
+function BlogEditor({ initialContent }: EditorProps) {
   const [editorState, setEditorState] = useState<SerializedEditorState>();
 
   return (
@@ -44,9 +46,19 @@ function Editor({ initialContent }: EditorProps) {
           }}
         />
       </LexicalComposer>
-      <pre>{JSON.stringify(editorState, null, 2)}</pre>
+      <Box
+        sx={{
+          marginTop: 2,
+          padding: 1,
+          fontFamily: "monospace",
+          whiteSpace: "pre-wrap",
+          wordBreak: "break-word",
+        }}
+      >
+        {JSON.stringify(editorState, null, 2)}
+      </Box>
     </>
   );
 }
 
-export default Editor;
+export default BlogEditor;

--- a/apps/front-end/src/resources/Blogs/components/ContentEditable.tsx
+++ b/apps/front-end/src/resources/Blogs/components/ContentEditable.tsx
@@ -1,0 +1,35 @@
+import type { ContentEditableProps } from "@lexical/react/LexicalContentEditable";
+import type { ForwardRefExoticComponent, RefAttributes } from "react";
+
+import { ContentEditable as LexicalContentEditable } from "@lexical/react/LexicalContentEditable";
+import Box from "@mui/material/Box";
+import Card from "@mui/material/Card";
+
+function ContentEditable(
+  props?: Omit<
+    ForwardRefExoticComponent<ContentEditableProps & RefAttributes<HTMLDivElement>>,
+    "$$typeof"
+  >,
+) {
+  return (
+    <Card sx={{ minWidth: 0 }}>
+      <Box
+        component={LexicalContentEditable}
+        className="editor-input"
+        sx={{
+          outline: "none",
+          minHeight: 150,
+          typography: "body1",
+          padding: 1,
+          minWidth: 0,
+          whiteSpace: "pre-wrap",
+          wordBreak: "break-word",
+          overflowWrap: "break-word",
+        }}
+        {...props}
+      />
+    </Card>
+  );
+}
+
+export default ContentEditable;

--- a/apps/front-end/src/resources/Blogs/pages/CreateBlog.tsx
+++ b/apps/front-end/src/resources/Blogs/pages/CreateBlog.tsx
@@ -1,0 +1,13 @@
+import { Page } from "@alextheman/components";
+
+import BlogEditor from "src/resources/Blogs/components/BlogEditor";
+
+function CreateBlog() {
+  return (
+    <Page title="Create Blog">
+      <BlogEditor />
+    </Page>
+  );
+}
+
+export default CreateBlog;

--- a/apps/front-end/src/resources/Users/pages/UserProfile.tsx
+++ b/apps/front-end/src/resources/Users/pages/UserProfile.tsx
@@ -1,4 +1,5 @@
 import { Page } from "@alextheman/components";
+import { DropdownMenuItem, DropdownMenuWrapper, InternalLink } from "@alextheman/components/v7";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import CardHeader from "@mui/material/CardHeader";
@@ -18,7 +19,17 @@ function UserProfile({ userId }: UserProfileProps) {
     <QueryBoundary data={user} isLoading={isPending} error={error}>
       {(user) => {
         return (
-          <Page title={user.displayName ?? user.username} subtitle={user.username}>
+          <Page
+            title={user.displayName ?? user.username}
+            subtitle={user.username}
+            action={
+              <DropdownMenuWrapper>
+                <DropdownMenuItem component={InternalLink} to="/blogs/new">
+                  Create Blog
+                </DropdownMenuItem>
+              </DropdownMenuWrapper>
+            }
+          >
             <Card>
               <CardHeader title="Description" />
               <Divider />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,7 +140,7 @@ importers:
     dependencies:
       '@alextheman/components':
         specifier: 6.15.8
-        version: 6.15.8(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@mui/material@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@tanstack/react-form@1.29.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-hook-form@7.72.1(react@19.2.5))(react-router-dom@7.14.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(wouter@3.9.0(react@19.2.5))
+        version: 6.15.8(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@mui/material@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@tanstack/react-form@1.29.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-hook-form@7.74.0(react@19.2.5))(react-router-dom@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(wouter@3.9.0(react@19.2.5))
       '@emotion/react':
         specifier: 11.14.0
         version: 11.14.0(@types/react@19.2.14)(react@19.2.5)
@@ -1492,8 +1492,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@tanstack/form-core@1.29.0':
-    resolution: {integrity: sha512-uyeKEdJBfbj0bkBSwvSYVRtWLOaXvfNX3CeVw1HqGOXVLxpBBGAqWdYLc+UoX/9xcoFwFXrjR9QqMPzvwm2yyQ==}
+  '@tanstack/form-core@1.29.1':
+    resolution: {integrity: sha512-NIYPO36eEu7nSWvMpbFDQaBWyVtnH/C8fsZ3/XpJUT4uOWgmxsiUvHGbTbDNIQTXAKIkhwEl0sUrqBNn2SfUnw==}
 
   '@tanstack/pacer-lite@0.1.1':
     resolution: {integrity: sha512-y/xtNPNt/YeyoVxE/JCx+T7yjEzpezmbb+toK8DDD1P4m7Kzs5YR956+7OKexG3f8aXgC3rLZl7b1V+yNUSy5w==}
@@ -1502,8 +1502,8 @@ packages:
   '@tanstack/query-core@5.100.1':
     resolution: {integrity: sha512-awvQhOO/2TrSCHE5LKKsXcvvj6WSBncwEcMFCB/ez0Qs0b17iyyivoGArNV3HFfXryZwCpnb/olsaBBKrIbtSw==}
 
-  '@tanstack/react-form@1.29.0':
-    resolution: {integrity: sha512-jj425NNX0QKqbUzqSNiYI3HCPHSk2df47acXCJyXczWOTmG81ECZGkgofgqamFsSU9kMiH6Di5RLUnftrlhWSw==}
+  '@tanstack/react-form@1.29.1':
+    resolution: {integrity: sha512-hVHk4g0phd0HxRsv2ry6Xt8BqmalT55Q3cokhJBCC1St0hcGZhgwJJbohm9atao45BPG9e55DGvtbwExqZe35g==}
     peerDependencies:
       '@tanstack/react-start': '*'
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -3987,8 +3987,8 @@ packages:
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
 
-  react-hook-form@7.72.1:
-    resolution: {integrity: sha512-RhwBoy2ygeVZje+C+bwJ8g0NjTdBmDlJvAUHTxRjTmSUKPYsKfMphkS2sgEMotsY03bP358yEYlnUeZy//D9Ig==}
+  react-hook-form@7.74.0:
+    resolution: {integrity: sha512-yR6wHr99p9wFv686jhRWVSFhUvDvNbdUf2dKlbno8/VKOCuoNobDGC6S+M2dua9A9Yo8vpcrp8assIYbsZCQ9g==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
@@ -4011,15 +4011,15 @@ packages:
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
 
-  react-router-dom@7.14.1:
-    resolution: {integrity: sha512-ZkrQuwwhGibjQLqH1eCdyiZyLWglPxzxdl5tgwgKEyCSGC76vmAjleGocRe3J/MLfzMUIKwaFJWpFVJhK3d2xA==}
+  react-router-dom@7.14.2:
+    resolution: {integrity: sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
       react-dom: '>=18'
 
-  react-router@7.14.1:
-    resolution: {integrity: sha512-5BCvFskyAAVumqhEKh/iPhLOIkfxcEUz8WqFIARCkMg8hZZzDYX9CtwxXA0e+qT8zAxmMC0x3Ckb9iMONwc5jg==}
+  react-router@7.14.2:
+    resolution: {integrity: sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -4828,20 +4828,20 @@ snapshots:
   '@acemir/cssom@0.9.31':
     optional: true
 
-  '@alextheman/components@6.15.8(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@mui/material@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@tanstack/react-form@1.29.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-hook-form@7.72.1(react@19.2.5))(react-router-dom@7.14.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(wouter@3.9.0(react@19.2.5))':
+  '@alextheman/components@6.15.8(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@mui/material@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@tanstack/react-form@1.29.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-hook-form@7.74.0(react@19.2.5))(react-router-dom@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(wouter@3.9.0(react@19.2.5))':
     dependencies:
       '@alextheman/utility': 5.14.0
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.5)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5)
       '@mui/material': 9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@tanstack/react-form': 1.29.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/react-form': 1.29.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       common-tags: 1.8.2
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
-      react-hook-form: 7.72.1(react@19.2.5)
+      react-hook-form: 7.74.0(react@19.2.5)
       react-icons: 5.6.0(react@19.2.5)
       react-live: 4.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      react-router-dom: 7.14.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react-router-dom: 7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       wouter: 3.9.0(react@19.2.5)
       zod: 4.3.6
 
@@ -5982,7 +5982,7 @@ snapshots:
 
   '@tanstack/devtools-event-client@0.4.3': {}
 
-  '@tanstack/form-core@1.29.0':
+  '@tanstack/form-core@1.29.1':
     dependencies:
       '@tanstack/devtools-event-client': 0.4.3
       '@tanstack/pacer-lite': 0.1.1
@@ -5992,9 +5992,9 @@ snapshots:
 
   '@tanstack/query-core@5.100.1': {}
 
-  '@tanstack/react-form@1.29.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@tanstack/react-form@1.29.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@tanstack/form-core': 1.29.0
+      '@tanstack/form-core': 1.29.1
       '@tanstack/react-store': 0.9.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
     transitivePeerDependencies:
@@ -8770,7 +8770,7 @@ snapshots:
     dependencies:
       react: 19.2.5
 
-  react-hook-form@7.72.1(react@19.2.5):
+  react-hook-form@7.74.0(react@19.2.5):
     dependencies:
       react: 19.2.5
 
@@ -8790,13 +8790,13 @@ snapshots:
       sucrase: 3.35.1
       use-editable: 2.3.3(react@19.2.5)
 
-  react-router-dom@7.14.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  react-router-dom@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
-      react-router: 7.14.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react-router: 7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
 
-  react-router@7.14.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  react-router@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       cookie: 1.1.1
       react: 19.2.5


### PR DESCRIPTION
Although we can't use a TextField directly, we can still style it based on Material UI components and get things like word-wrapping with it (that Goddamn pre component messed with me, though...)

# New Feature

This is a new feature for `lexicon`. It adds new functionality to the app.

Please see the commits tab of this pull request for the description of changes.
