### PR TITLE
Remove the env.DATABASE_URL variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,6 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
-    env:
-      DATABASE_URL: postgresql://postgres:lexicon@localhost:5432/tests?schema=public
 
     steps:
       - name: Checkout the repository


### PR DESCRIPTION
I don't think we need it given that we initialise the back-end environment variables as a later step. This should reduce duplication.

# Tooling Change

This is a change to the tooling of `lexicon`. It changes the internal workings of the app and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
