### PR TITLE
Try a globbed cache path in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,12 +49,7 @@ jobs:
       - name: Cache Turborepo cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          path: |
-            .turbo
-            apps/back-end/.turbo
-            apps/front-end/.turbo
-            packages/models/.turbo
-            packages/configs/.turbo
+          path: "**/.turbo"
           key: turbo-${{ hashFiles('{apps,packages}/**', 'package.json', 'pnpm-lock.yaml', 'pnpm-workspace.yaml', 'turbo.json') }}
           restore-keys: turbo-
 


### PR DESCRIPTION
This may make the caching slightly easier if this works, as it will automatically store all the Turborepo cache as opposed to us having to specify all of them in the workflow every time.

# Tooling Change

This is a change to the tooling of `lexicon`. It changes the internal workings of the app and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
