### PR TITLE
Build the models package before running the tests

### DIFF
--- a/apps/back-end/tests/setup.ts
+++ b/apps/back-end/tests/setup.ts
@@ -1,8 +1,13 @@
 import { parseBoolean } from "@alextheman/utility";
 import { execa } from "execa";
 
+import path from "node:path";
+
 export async function setup() {
-  if (!process.env.CI && !parseBoolean(process.env.SKIP_RECREATE_DB ?? "false")) {
+  if (!process.env.CI && !parseBoolean(process.env.SKIP_SETUP ?? "false")) {
+    await execa({
+      cwd: path.join(process.cwd(), "..", "..", "packages", "models"),
+    })`pnpm run build`;
     await execa`pnpm run recreate-test-db`;
   }
 }


### PR DESCRIPTION
This ensures we don't run tests against a stale build of the models package after making changes to it.

# Tooling Change

This is a change to the tooling of `lexicon`. It changes the internal workings of the app and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
