### PR TITLE
Add error handling for the mutation routes

### DIFF
--- a/apps/front-end/package.json
+++ b/apps/front-end/package.json
@@ -30,7 +30,7 @@
     "update-dependencies": "pnpm update --latest && pnpm update"
   },
   "dependencies": {
-    "@alextheman/components": "6.15.9",
+    "@alextheman/components": "6.16.0",
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.1",
     "@lexicon/models": "workspace:*",

--- a/apps/front-end/src/App.tsx
+++ b/apps/front-end/src/App.tsx
@@ -1,4 +1,4 @@
-import { ModeProvider } from "@alextheman/components";
+import { ModeProvider, SnackbarProvider } from "@alextheman/components";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import AuthContextProvider from "src/AuthContextProvider";
@@ -11,7 +11,9 @@ function App() {
     <ModeProvider>
       <QueryClientProvider client={queryClient}>
         <AuthContextProvider>
-          <Router />
+          <SnackbarProvider>
+            <Router />
+          </SnackbarProvider>
         </AuthContextProvider>
       </QueryClientProvider>
     </ModeProvider>

--- a/apps/front-end/src/resources/Users/pages/EditUserProfile.tsx
+++ b/apps/front-end/src/resources/Users/pages/EditUserProfile.tsx
@@ -1,26 +1,31 @@
 import type { UserProfileFormOutputData } from "@lexicon/models";
 
-import { Page } from "@alextheman/components";
+import { Page, useSnackbar } from "@alextheman/components";
 import { useLocation } from "wouter";
 
 import { useAuth } from "src/AuthContextProvider";
 import QueryBoundary from "src/components/QueryBoundary";
 import UserProfileForm from "src/components/UserProfileForm";
 import { useUpdateUserProfileMutation } from "src/resources/Users/queries";
+import formatError from "src/utility/errors/formatError";
 
 function EditUserProfile() {
   const { currentUser, currentUserLoading } = useAuth();
   const { mutateAsync: updateUserProfile } = useUpdateUserProfileMutation();
   const [_, setLocation] = useLocation();
+  const { addSnackbar } = useSnackbar();
 
   async function onSubmit(data: UserProfileFormOutputData) {
-    await updateUserProfile(data);
-    setLocation(`/users/${currentUser?.id}`);
-    // TODO: Implement error handling pattern
+    try {
+      await updateUserProfile(data);
+      setLocation(`/users/${currentUser?.id}`);
+    } catch (error) {
+      addSnackbar(formatError(error), "error");
+    }
   }
 
   return (
-    <Page title="Edit Profile">
+    <Page title="Edit Profile" disablePadding>
       <QueryBoundary isLoading={currentUserLoading} data={currentUser}>
         {(user) => {
           return <UserProfileForm user={user} onSubmit={onSubmit} />;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,8 +145,8 @@ importers:
   apps/front-end:
     dependencies:
       '@alextheman/components':
-        specifier: 6.15.9
-        version: 6.15.9(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@mui/material@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@tanstack/react-form@1.29.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-hook-form@7.74.0(react@19.2.5))(react-router-dom@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(wouter@3.9.0(react@19.2.5))
+        specifier: 6.16.0
+        version: 6.16.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@mui/material@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@tanstack/react-form@1.29.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-hook-form@7.75.0(react@19.2.5))(react-router-dom@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(wouter@3.9.0(react@19.2.5))
       '@emotion/react':
         specifier: 11.14.0
         version: 11.14.0(@types/react@19.2.14)(react@19.2.5)
@@ -236,8 +236,8 @@ packages:
   '@acemir/cssom@0.9.31':
     resolution: {integrity: sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==}
 
-  '@alextheman/components@6.15.9':
-    resolution: {integrity: sha512-jWQrBHpkhLPlcrAzVxMTkrM6pYZKe0ifG1SCDTpfzM/AyHnkxGZELy6wvUmm7rpGPD2ZwylCXfw9yvXBg3gyDg==}
+  '@alextheman/components@6.16.0':
+    resolution: {integrity: sha512-I0rTmYV2i9sUZBCd1EGcaGn9WRcepez3yOWSNH7t1Xmx4UGds/rcvtDTLNb/CbOPTtvC8AY5JdQP0gu/QmwVMw==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       '@emotion/react': '>=11.0.0'
@@ -4004,8 +4004,8 @@ packages:
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
 
-  react-hook-form@7.74.0:
-    resolution: {integrity: sha512-yR6wHr99p9wFv686jhRWVSFhUvDvNbdUf2dKlbno8/VKOCuoNobDGC6S+M2dua9A9Yo8vpcrp8assIYbsZCQ9g==}
+  react-hook-form@7.75.0:
+    resolution: {integrity: sha512-Ovv94H+0p3sJ7B9B5QxPuCP1u8V/cHuVGyH55cSwodYDtoJwK+fqk3vjfIgSX59I2U/bU4z0nRJ9HMLpNiWEmw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
@@ -4837,7 +4837,7 @@ snapshots:
   '@acemir/cssom@0.9.31':
     optional: true
 
-  '@alextheman/components@6.15.9(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@mui/material@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@tanstack/react-form@1.29.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-hook-form@7.74.0(react@19.2.5))(react-router-dom@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(wouter@3.9.0(react@19.2.5))':
+  '@alextheman/components@6.16.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@mui/material@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@tanstack/react-form@1.29.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-hook-form@7.75.0(react@19.2.5))(react-router-dom@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(wouter@3.9.0(react@19.2.5))':
     dependencies:
       '@alextheman/utility': 5.16.1(zod@4.4.2)
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.5)
@@ -4847,7 +4847,7 @@ snapshots:
       common-tags: 1.8.2
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
-      react-hook-form: 7.74.0(react@19.2.5)
+      react-hook-form: 7.75.0(react@19.2.5)
       react-icons: 5.6.0(react@19.2.5)
       react-live: 4.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react-router-dom: 7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -8730,7 +8730,7 @@ snapshots:
     dependencies:
       react: 19.2.5
 
-  react-hook-form@7.74.0(react@19.2.5):
+  react-hook-form@7.75.0(react@19.2.5):
     dependencies:
       react: 19.2.5
 


### PR DESCRIPTION
For errors from POST/PUT routes, instead of displaying a more permanent error on the page directly, they should instead be snackbars that display on-screen temporarily before being removed. Errors from POST/PUT requests are often errors that are actionable by the user so it's often better to either show them as helper text on the form or contextual errors shown as snackbars. This ensures visibility of the error at hand without cluttering up the page with outdated error messages.

# Refactor

This is a change to the code layout of `lexicon`. It changes how the code is presented in terms of quality and structure without changing its overall user-facing behaviour or functionality.

Please see the commits tab of this pull request for the description of changes.
