### PR TITLE
Add a QueryBoundaryDataRowsMap

### DIFF
--- a/apps/front-end/src/components/QueryBoundaryDataRowsMap.tsx
+++ b/apps/front-end/src/components/QueryBoundaryDataRowsMap.tsx
@@ -1,0 +1,76 @@
+import type { QueryBoundaryDataMapProps } from "@alextheman/components";
+import type { ReactNode } from "react";
+
+import { QueryBoundaryDataMap, SkeletonRow } from "@alextheman/components";
+import TableCell from "@mui/material/TableCell";
+import TableRow from "@mui/material/TableRow";
+
+export type QueryBoundaryDataRowsMap<ItemType> = Omit<
+  QueryBoundaryDataMapProps<ItemType>,
+  "emptyComponent" | "loadingComponent"
+> & {
+  columns: number;
+  emptyComponent?: ReactNode | ((columns: number) => ReactNode);
+  loadingComponent?: ReactNode | ((columns: number) => ReactNode);
+};
+
+function QueryBoundaryDataRowsMap<ItemType>({
+  columns,
+  loadingComponent = (columns) => {
+    return <SkeletonRow columns={columns} />;
+  },
+  emptyComponent = (columns) => {
+    return (
+      <TableRow>
+        <TableCell colSpan={columns}>No data available.</TableCell>
+      </TableRow>
+    );
+  },
+  children,
+  itemParser,
+  dataParser,
+  ...props
+}: QueryBoundaryDataRowsMap<ItemType>) {
+  const resolvedLoadingComponent =
+    typeof loadingComponent === "function" ? loadingComponent(columns) : loadingComponent;
+  const resolvedEmptyComponent =
+    typeof emptyComponent === "function" ? emptyComponent(columns) : emptyComponent;
+
+  if (dataParser) {
+    return (
+      <QueryBoundaryDataMap
+        emptyComponent={resolvedEmptyComponent}
+        loadingComponent={resolvedLoadingComponent}
+        dataParser={dataParser}
+        {...props}
+      >
+        {children}
+      </QueryBoundaryDataMap>
+    );
+  }
+
+  if (itemParser) {
+    return (
+      <QueryBoundaryDataMap
+        emptyComponent={resolvedEmptyComponent}
+        loadingComponent={resolvedLoadingComponent}
+        itemParser={itemParser}
+        {...props}
+      >
+        {children}
+      </QueryBoundaryDataMap>
+    );
+  }
+
+  return (
+    <QueryBoundaryDataMap
+      emptyComponent={resolvedEmptyComponent}
+      loadingComponent={resolvedLoadingComponent}
+      {...props}
+    >
+      {children}
+    </QueryBoundaryDataMap>
+  );
+}
+
+export default QueryBoundaryDataRowsMap;

--- a/apps/front-end/src/resources/Blogs/pages/Blogs.tsx
+++ b/apps/front-end/src/resources/Blogs/pages/Blogs.tsx
@@ -1,4 +1,4 @@
-import { Page, QueryBoundaryError, SkeletonRow } from "@alextheman/components";
+import { Page, QueryBoundaryError } from "@alextheman/components";
 import { InternalLink } from "@alextheman/components/v7";
 import { formatDateAndTime } from "@alextheman/utility";
 import { parseBlogSummary } from "@lexicon/models";
@@ -10,7 +10,7 @@ import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 
-import QueryBoundaryDataMap from "src/components/QueryBoundaryDataMap";
+import QueryBoundaryDataRowsMap from "src/components/QueryBoundaryDataRowsMap";
 import QueryBoundaryProvider from "src/components/QueryBoundaryProvider";
 import { useBlogsQuery } from "src/resources/Blogs/queries";
 
@@ -32,10 +32,7 @@ function Blogs() {
                 </TableRow>
               </TableHead>
               <TableBody>
-                <QueryBoundaryDataMap
-                  itemParser={parseBlogSummary}
-                  loadingComponent={<SkeletonRow columns={3} />}
-                >
+                <QueryBoundaryDataRowsMap itemParser={parseBlogSummary} columns={3}>
                   {(blog) => {
                     return (
                       <TableRow>
@@ -53,7 +50,7 @@ function Blogs() {
                       </TableRow>
                     );
                   }}
-                </QueryBoundaryDataMap>
+                </QueryBoundaryDataRowsMap>
               </TableBody>
             </Table>
           </TableContainer>


### PR DESCRIPTION
This further abstracts out some QueryBoundaryDataRows behaviour by allowing the caller to instead directly provide the amount of columns to display in the loadingComponent and emptyComponent, which prevents potential mistakes from being inconsistent with the column count and also saves a SkeletonRow import everywhere.

# Refactor

This is a change to the code layout of `lexicon`. It changes how the code is presented in terms of quality and structure without changing its overall user-facing behaviour or functionality.

Please see the commits tab of this pull request for the description of changes.
