### PR TITLE
Add an AuthRequired component

### DIFF
--- a/apps/front-end/src/components/AuthRequired.tsx
+++ b/apps/front-end/src/components/AuthRequired.tsx
@@ -1,0 +1,47 @@
+import type { User } from "@lexicon/models";
+import type { ReactNode } from "react";
+
+import { ErrorPage } from "@alextheman/components/v7";
+import axios from "axios";
+
+import { useAuth } from "src/AuthContextProvider";
+import QueryBoundary from "src/components/QueryBoundary";
+import { DEFAULT_ERROR_MESSAGE } from "src/utility/errors/DEFAULT_ERROR_MESSAGE";
+import defaultErrorFormatters from "src/utility/errors/errorFormatters";
+
+export interface AuthRequiredProps {
+  unauthorisedMessage?: string;
+  children: ReactNode | ((currentUser: User) => ReactNode);
+}
+
+function AuthRequired({
+  children,
+  unauthorisedMessage = "You do not have permission to access this page.",
+}: AuthRequiredProps) {
+  const { currentUser, currentUserLoading, currentUserError } = useAuth();
+
+  return (
+    <QueryBoundary
+      data={currentUser}
+      isLoading={currentUserLoading}
+      error={currentUserError}
+      nullComponent={<ErrorPage title="Unauthorised">{unauthorisedMessage}</ErrorPage>}
+      codeErrorMap={{ ...defaultErrorFormatters, AUTH_REQUIRED: unauthorisedMessage }}
+      errorFunction={(error) => {
+        if (
+          axios.isAxiosError(error) &&
+          (error.response?.status === 401 || error.response?.status === 403)
+        ) {
+          return unauthorisedMessage;
+        }
+        return DEFAULT_ERROR_MESSAGE;
+      }}
+    >
+      {(user) => {
+        return typeof children === "function" ? children(user) : children;
+      }}
+    </QueryBoundary>
+  );
+}
+
+export default AuthRequired;

--- a/apps/front-end/src/resources/Blogs/pages/CreateBlog.tsx
+++ b/apps/front-end/src/resources/Blogs/pages/CreateBlog.tsx
@@ -12,7 +12,7 @@ import { useState } from "react";
 import { useLocation } from "wouter";
 import z from "zod";
 
-import { useAuth } from "src/AuthContextProvider";
+import AuthRequired from "src/components/AuthRequired";
 import useAppForm from "src/hooks/useAppForm";
 import BlogEditor from "src/resources/Blogs/components/BlogEditor";
 import { useCreateBlogMutation } from "src/resources/Blogs/queries";
@@ -25,7 +25,6 @@ const blogCreationSchema = z.object({
 function CreateBlog() {
   const [editorState, setEditorState] = useState<SerializedEditorState | undefined>();
   const { mutateAsync: uploadBlog, isPending } = useCreateBlogMutation();
-  const { currentUser } = useAuth();
   const [_, setLocation] = useLocation();
   const { addSnackbar } = useSnackbar();
 
@@ -60,36 +59,42 @@ function CreateBlog() {
   });
 
   return (
-    <form
-      onSubmit={async (event) => {
-        event.preventDefault();
-        await form.handleSubmit();
-      }}
-    >
-      <Page
-        title={
-          <form.AppField name="title">
-            {(field) => {
-              return <field.TextField label="Title" fullWidth />;
+    <AuthRequired unauthorisedMessage="You must be signed in to create a blog.">
+      {(currentUser) => {
+        return (
+          <form
+            onSubmit={async (event) => {
+              event.preventDefault();
+              await form.handleSubmit();
             }}
-          </form.AppField>
-        }
-        disablePadding
-      >
-        <CardContent>
-          <BlogEditor setEditorState={setEditorState} />
-        </CardContent>
-        <Divider />
-        <CardActions>
-          <Stack direction="row" spacing={2}>
-            <form.AppForm>
-              <form.BackButton to={`/users/${currentUser?.id}`} />
-              <form.SubmitButton disabled={editorState === undefined} loading={isPending} />
-            </form.AppForm>
-          </Stack>
-        </CardActions>
-      </Page>
-    </form>
+          >
+            <Page
+              title={
+                <form.AppField name="title">
+                  {(field) => {
+                    return <field.TextField label="Title" fullWidth />;
+                  }}
+                </form.AppField>
+              }
+              disablePadding
+            >
+              <CardContent>
+                <BlogEditor setEditorState={setEditorState} />
+              </CardContent>
+              <Divider />
+              <CardActions>
+                <Stack direction="row" spacing={2}>
+                  <form.AppForm>
+                    <form.BackButton to={`/users/${currentUser.id}`} />
+                    <form.SubmitButton disabled={editorState === undefined} loading={isPending} />
+                  </form.AppForm>
+                </Stack>
+              </CardActions>
+            </Page>
+          </form>
+        );
+      }}
+    </AuthRequired>
   );
 }
 


### PR DESCRIPTION
This will wrap around pages that require the user to be signed in in order to access them. For example, the blog creation page does not make sense to access without authentication.

# New Feature

This is a new feature for `lexicon`. It adds new functionality to the app.

Please see the commits tab of this pull request for the description of changes.
