### PR TITLE
Update utility and use fillArray again

### DIFF
--- a/apps/back-end/tests/server/blogs.test.ts
+++ b/apps/back-end/tests/server/blogs.test.ts
@@ -1,11 +1,11 @@
-import type { Blog, BlogInsertData } from "@lexicon/models";
+import type { BlogInsertData } from "@lexicon/models";
 
 import {
   assertNotNull,
   assertNotUndefined,
+  fillArray,
   isSameDate,
   omitProperties,
-  range,
 } from "@alextheman/utility";
 import { DataError } from "@alextheman/utility/v6";
 import { BlogState, parseBlogSummaries, parseBlogView } from "@lexicon/models";
@@ -27,12 +27,13 @@ describe("GET", () => {
     test("Returns all the blogs from all users", async () => {
       const { connection, factory, authenticatedClient } = await getTestFixtures();
 
-      const blogs: Array<Blog> = [];
-
-      // TODO: Allow fillArray to take a sequential option to address the warning about calling client.query() when it is already executing a query.
-      for (const _ of range(0, 10)) {
-        blogs.push(await factory.blogs.insert());
-      }
+      const blogs = await fillArray(
+        async () => {
+          return await factory.blogs.insert();
+        },
+        10,
+        { sequential: true },
+      );
 
       const blogIds = blogs.map((blog) => {
         return blog.id;

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     }
   },
   "dependencies": {
-    "@alextheman/utility": "5.17.1",
+    "@alextheman/utility": "5.18.0",
     "@lexical/react": "0.44.0",
     "lexical": "0.44.0",
     "zod": "4.4.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,8 +14,8 @@ importers:
   .:
     dependencies:
       '@alextheman/utility':
-        specifier: 5.17.1
-        version: 5.17.1(zod@4.4.2)
+        specifier: 5.18.0
+        version: 5.18.0(zod@4.4.2)
       '@lexical/react':
         specifier: 0.44.0
         version: 0.44.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(yjs@13.6.29)
@@ -283,8 +283,8 @@ packages:
     peerDependencies:
       zod: '>=4.0.0'
 
-  '@alextheman/utility@5.17.1':
-    resolution: {integrity: sha512-E/es6Ra14WqAEuA793Y1n7N2YR+oD0tB0Q0POneyz6thi5nWu7S3sjuh5UpxgZnKob3LDLYPpBuX1wyn/wxYxw==}
+  '@alextheman/utility@5.18.0':
+    resolution: {integrity: sha512-k7zGNOxIruhysZ7o1jMixRlX7vn4pM+NbswbYpDGRx1MXJIwDxrEG6j/tneh98j451nQTD5W1y72ZcA6AcmmDw==}
     engines: {node: '>=22.3.0'}
     peerDependencies:
       zod: '>=4.0.0'
@@ -1599,6 +1599,9 @@ packages:
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
@@ -3483,8 +3486,8 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
-  lru-cache@11.3.5:
-    resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
+  lru-cache@11.3.6:
+    resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
     engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
@@ -4898,7 +4901,7 @@ snapshots:
       execa: 9.6.1
       zod: 4.4.2
 
-  '@alextheman/utility@5.17.1(zod@4.4.2)':
+  '@alextheman/utility@5.18.0(zod@4.4.2)':
     dependencies:
       dotenv: 17.4.2
       execa: 9.6.1
@@ -4921,7 +4924,7 @@ snapshots:
       bidi-js: 1.0.3
       css-tree: 3.2.1
       is-potential-custom-element-name: 1.0.1
-      lru-cache: 11.3.5
+      lru-cache: 11.3.6
     optional: true
 
   '@asamuzakjp/generational-cache@1.0.1':
@@ -5902,7 +5905,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.1
+      '@tybys/wasm-util': 0.10.2
     optional: true
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
@@ -6046,6 +6049,11 @@ snapshots:
     optional: true
 
   '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -6809,7 +6817,7 @@ snapshots:
       '@asamuzakjp/css-color': 5.1.11
       '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
       css-tree: 3.2.1
-      lru-cache: 11.3.5
+      lru-cache: 11.3.6
     optional: true
 
   csstype@3.2.3: {}
@@ -7705,7 +7713,7 @@ snapshots:
 
   hosted-git-info@9.0.3:
     dependencies:
-      lru-cache: 11.3.5
+      lru-cache: 11.3.6
 
   html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
     dependencies:
@@ -8098,7 +8106,7 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
-  lru-cache@11.3.5: {}
+  lru-cache@11.3.6: {}
 
   lru-cache@5.1.1:
     dependencies:


### PR DESCRIPTION
fillArray now has the option to resolve each asynchronous callback sequentially, therefore getting rid of the client.query() warning where we query the same client multiple times by resolving each item in parallel.

# Refactor

This is a change to the code layout of `lexicon`. It changes how the code is presented in terms of quality and structure without changing its overall user-facing behaviour or functionality.

Please see the commits tab of this pull request for the description of changes.
