### PR TITLE
Replace setConnection with a mock of getConnection

### DIFF
--- a/apps/back-end/src/database/connection.ts
+++ b/apps/back-end/src/database/connection.ts
@@ -38,14 +38,10 @@ export type Connection = NodePgDatabase<typeof schema> & {
   $client?: Pool | PoolClient;
 };
 
-let connection: Connection = drizzle(pool, { schema });
+const connection: Connection = drizzle(pool, { schema });
 
 export function getConnection(): Connection {
   return connection;
-}
-
-export function setConnection(newConnection: Connection): void {
-  connection = newConnection;
 }
 
 export { pool };

--- a/apps/back-end/tests/isolation.ts
+++ b/apps/back-end/tests/isolation.ts
@@ -1,27 +1,31 @@
 import type { PoolClient } from "pg";
 
+import type { getConnection } from "src/database/connection";
+
 import { sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/node-postgres";
-import { afterEach, beforeEach } from "vitest";
+import { afterEach, beforeEach, vi } from "vitest";
 
-import { getConnection, pool, setConnection } from "src/database/connection";
+import { pool } from "src/database/connection";
+// eslint-disable-next-line @alextheman/no-namespace-imports
+import * as dbModule from "src/database/connection";
 // eslint-disable-next-line @alextheman/no-namespace-imports
 import * as schema from "src/database/schema";
 
 let client: PoolClient;
+let testConnection: ReturnType<typeof getConnection>;
 
 beforeEach(async () => {
   client = await pool.connect();
 
-  const testConnection = drizzle(client, { schema });
-  setConnection(testConnection);
+  testConnection = drizzle(client, { schema });
 
-  const connection = getConnection();
-  await connection.execute(sql`BEGIN`);
+  vi.spyOn(dbModule, "getConnection").mockReturnValue(testConnection);
+  await testConnection.execute(sql`BEGIN`);
 });
 
 afterEach(async () => {
-  const connection = getConnection();
-  await connection.execute(sql`ROLLBACK`);
+  await testConnection.execute(sql`ROLLBACK`);
+  vi.restoreAllMocks();
   client.release();
 });


### PR DESCRIPTION
This is a much safer pattern - setConnection was previously exposed everywhere, including in production code, which was risky. Now we just override the value of getConnection using the spy, which allows the test to use its own connection while production cannot ever mutate the current connection.

# Refactor

This is a change to the code layout of `lexicon`. It changes how the code is presented in terms of quality and structure without changing its overall user-facing behaviour or functionality.

Please see the commits tab of this pull request for the description of changes.
