### PR TITLE
Exclude my own packages from minimumReleaseAge

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,6 @@ allowBuilds:
 patchedDependencies:
   eslint-plugin-react: patches/eslint-plugin-react.patch
 savePrefix: ""
+minimumReleaseAgeExclude:
+  - "@alextheman/*"
+  - alex-c-line


### PR DESCRIPTION
As of pnpm v11, the default minimumReleaseAge is now one day. However, for my own packages I would most likely always want to use the latest version given that they are my packages and I know exactly what goes into each version. As such, they need to be excluded to ensure my own packages don't drift out of sync with each other.

# Tooling Change

This is a change to the tooling of `lexicon`. It changes the internal workings of the app and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
