### PR TITLE
Use our QueryBoundaryDataMap in our QueryBoundaryDataRowsMap

### DIFF
--- a/apps/front-end/src/components/QueryBoundaryDataRowsMap.tsx
+++ b/apps/front-end/src/components/QueryBoundaryDataRowsMap.tsx
@@ -1,9 +1,11 @@
 import type { QueryBoundaryDataMapProps } from "@alextheman/components";
 import type { ReactNode } from "react";
 
-import { QueryBoundaryDataMap, QueryBoundaryNullable, SkeletonRow } from "@alextheman/components";
+import { QueryBoundaryNullable, SkeletonRow } from "@alextheman/components";
 import TableCell from "@mui/material/TableCell";
 import TableRow from "@mui/material/TableRow";
+
+import QueryBoundaryDataMap from "src/components/QueryBoundaryDataMap";
 
 type FallbackComponent = ReactNode | ((columns: number) => ReactNode);
 


### PR DESCRIPTION
This ensures that we use the resource ID wherever possible.

# Refactor

This is a change to the code layout of `lexicon`. It changes how the code is presented in terms of quality and structure without changing its overall user-facing behaviour or functionality.

Please see the commits tab of this pull request for the description of changes.
