### PR TITLE
Remove corepack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,6 @@ FROM ghcr.io/pnpm/pnpm:latest
 
 WORKDIR /app
 
-RUN ["corepack", "enable"]
-RUN ["corepack", "prepare", "pnpm", "--activate"]
-
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
 COPY apps ./apps
 COPY packages ./packages


### PR DESCRIPTION
I don't think the Dockerfile actually needs it.

# Tooling Change

This is a change to the tooling of `lexicon`. It changes the internal workings of the app and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
