### PR TITLE
Do not load environment variables with dotenv in production

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -30,19 +30,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Initialise environment variables
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-        run: |
-          touch apps/back-end/.env.production
-          echo "DATABASE_URL=$DATABASE_URL" >> apps/back-end/.env.production
-
-      - name: Build packages
-        run: pnpm run build
-
       - name: Apply migrations
         working-directory: apps/back-end
         env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
           NODE_ENV: production
         run: pnpm run migrate-db
 

--- a/apps/back-end/drizzle.config.ts
+++ b/apps/back-end/drizzle.config.ts
@@ -5,10 +5,12 @@ import path from "node:path";
 
 const ENV = parseEnv(process.env.NODE_ENV ?? "development");
 
-dotenv.config({
-  path: path.resolve(process.cwd(), `.env.${ENV}`),
-  quiet: ENV === "test",
-});
+if (ENV !== "production") {
+  dotenv.config({
+    path: path.resolve(process.cwd(), `.env.${ENV}`),
+    quiet: ENV === "test",
+  });
+}
 
 const config: Config = {
   schema: "./src/database/schema/index.ts",

--- a/apps/back-end/src/database/connection.ts
+++ b/apps/back-end/src/database/connection.ts
@@ -16,10 +16,12 @@ const ENV = parseEnv(process.env.NODE_ENV ?? "development");
 
 const envFilePath = path.resolve(process.cwd(), `.env.${ENV}`);
 
-dotenv.config({
-  path: envFilePath,
-  quiet: ENV === "test",
-});
+if (ENV !== "production") {
+  dotenv.config({
+    path: envFilePath,
+    quiet: ENV === "test",
+  });
+}
 
 const { DATABASE_URL } = process.env;
 if (!DATABASE_URL) {


### PR DESCRIPTION
Environment variables in production can generally be declared with the service itself - it does not need to read from the .env file.

# Tooling Change

This is a change to the tooling of `lexicon`. It changes the internal workings of the app and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
