### PR TITLE
Remove the manual NODE_ENV from the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ RUN ["pnpm", "runtime", "set", "node", "22", "-g"]
 
 WORKDIR /app
 
-ENV NODE_ENV=production
-
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json tsconfig.json ./
 COPY apps ./apps
 COPY packages ./packages


### PR DESCRIPTION
I have figured out how to make Render recognise this now.

# Tooling Change

This is a change to the tooling of `lexicon`. It changes the internal workings of the app and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
