### PR TITLE
Log the API base URL for quick debugging

### DIFF
--- a/apps/front-end/src/App.tsx
+++ b/apps/front-end/src/App.tsx
@@ -9,6 +9,9 @@ import Router from "src/Router";
 const queryClient = new QueryClient();
 
 function App() {
+  // eslint-disable-next-line no-console
+  console.log(import.meta.env.VITE_API_BASE_URL);
+
   return (
     <ModeProvider>
       <ErrorBoundary FallbackComponent={ErrorPage}>


### PR DESCRIPTION
It doesn't seem to be being used in production for some reason, so quick log to confirm. The URL is not really secret anyway so it's fine to log it directly.

# Tooling Change

This is a change to the tooling of `lexicon`. It changes the internal workings of the app and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
