### PR TITLE
Use the VITE_API_BASE_URL environment variable in the workflow itself

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -50,14 +50,17 @@ jobs:
       - name: Pull Vercel Environment Information
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
         run: vercel pull --yes --environment=preview --token=$VERCEL_TOKEN
 
       - name: Build Project
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
         run: vercel build --token=$VERCEL_TOKEN
 
       - name: Create Deploy Preview
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
         run: vercel deploy --prebuilt --token=$VERCEL_TOKEN

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -96,14 +96,17 @@ jobs:
       - name: Pull Vercel Environment Information
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
         run: vercel pull --yes --environment=production --token=$VERCEL_TOKEN
 
       - name: Build Project
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
         run: vercel build --prod --token=$VERCEL_TOKEN
 
       - name: Deploy to Vercel
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
         run: vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN


### PR DESCRIPTION
Hopefully this will ensure the build recognises it. Note that the deploy preview one is using the production API base URL for now, but this will be changed in the future.

# Tooling Change

This is a change to the tooling of `lexicon`. It changes the internal workings of the app and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
