### PR TITLE
Replace the ALEX_UP_BOT_APP_ID secret with the coresponding actions v…

### DIFF
--- a/.github/workflows/restrict-alex-up-bot-branches.yml
+++ b/.github/workflows/restrict-alex-up-bot-branches.yml
@@ -13,5 +13,5 @@ jobs:
   restrict-alex-up-bot-branches:
     uses: alextheman231/github-actions/.github/workflows/restrict-alex-up-bot-branches.yml@c4545878d40d8cd0b3b08c8f693c27980b5f3e16 # v11.2.2
     secrets:
-      APP_ID: ${{ secrets.ALEX_UP_BOT_APP_ID }}
+      APP_ID: ${{ vars.ALEX_UP_BOT_APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.ALEX_UP_BOT_PRIVATE_KEY }}

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -13,7 +13,7 @@ jobs:
     if: ${{ github.repository == 'alextheman231/lexicon' }}
     uses: alextheman231/github-actions/.github/workflows/update-dependencies.yml@c4545878d40d8cd0b3b08c8f693c27980b5f3e16 # v11.2.2
     secrets:
-      APP_ID: ${{ secrets.ALEX_UP_BOT_APP_ID }}
+      APP_ID: ${{ vars.ALEX_UP_BOT_APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.ALEX_UP_BOT_PRIVATE_KEY }}
     with:
       update_pnpm: true


### PR DESCRIPTION
…ariable

It's not really a secret value so it doesn't need to be stored as a workflow secret.

# Tooling Change

This is a change to the tooling of `lexicon`. It changes the internal workings of the app and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
