### PR TITLE
Tag the Sentry release with the git commit hash

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -97,6 +97,7 @@ jobs:
       VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
       VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
       VITE_SENTRY_DSN: ${{ vars.FRONT_END_SENTRY_DSN }}
+      VITE_SENTRY_RELEASE: ${{ github.sha }}
     needs: [deploy-image]
     steps:
       - name: Checkout the repository
@@ -139,6 +140,7 @@ jobs:
           SENTRY_PROJECT: lexicon-front-end
         with:
           environment: production
+          release: ${{ env.VITE_SENTRY_RELEASE }}
           sourcemaps: apps/front-end/dist/assets
           ignore_missing: true
           ignore_empty: true

--- a/apps/front-end/src/main.tsx
+++ b/apps/front-end/src/main.tsx
@@ -11,6 +11,8 @@ import ErrorPage from "src/pages/ErrorPage";
 if (import.meta.env.PROD && import.meta.env.VITE_SENTRY_DSN) {
   init({
     dsn: import.meta.env.VITE_SENTRY_DSN,
+    release: import.meta.env.VITE_SENTRY_RELEASE,
+    environment: import.meta.env.MODE,
   });
 }
 


### PR DESCRIPTION
This ensures the error reporting can also point back to the commit that caused the error, which can be helpful.

# Tooling Change

This is a change to the tooling of `lexicon`. It changes the internal workings of the app and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
