### PR TITLE
Cache the deployment by SHA

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: "**/.turbo"
-          key: deployment-build
+          key: deployment-build-${{ github.sha }}
 
   deploy-database:
     runs-on: ubuntu-latest
@@ -67,7 +67,7 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: "**/.turbo"
-          key: deployment-build
+          key: deployment-build-${{ github.sha }}
 
       - name: Install dependencies
         run: pnpm install
@@ -98,7 +98,7 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: "**/.turbo"
-          key: deployment-build
+          key: deployment-build-${{ github.sha }}
 
       - name: Login to Docker Hub
         env:
@@ -181,7 +181,7 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: "**/.turbo"
-          key: deployment-build
+          key: deployment-build-${{ github.sha }}
 
       - name: Install Vercel
         uses: alextheman231/typescript-actions/actions/safe-npm-dependency-global-install@52cf8adbb2d435944bbd882e03d0be6cdaeac243 # v1.2.1

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -94,12 +94,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Restore build cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: "**/.turbo"
-          key: deployment-build-${{ github.sha }}
-
       - name: Login to Docker Hub
         env:
           DOCKER_USERNAME: ${{ vars.DOCKER_USERNAME }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ COPY patches ./patches
 
 RUN ["pnpm", "install", "--frozen-lockfile"]
 RUN ["pnpm", "run", "build", "--ui=stream"]
-RUN ["rm", "-rf", "**/.turbo"]
 
 EXPOSE 8080
 


### PR DESCRIPTION
Otherwise newer runs can sometimes fail to create the cache as it is not unique per job anymore.

# Tooling Change

This is a change to the tooling of `lexicon`. It changes the internal workings of the app and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
