### PR TITLE
Update components and refactor QueryBoundary usage

### DIFF
--- a/apps/front-end/package.json
+++ b/apps/front-end/package.json
@@ -30,7 +30,7 @@
     "update-dependencies": "pnpm update --latest && pnpm update"
   },
   "dependencies": {
-    "@alextheman/components": "6.18.1",
+    "@alextheman/components": "6.19.0",
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.1",
     "@lexical/react": "0.44.0",

--- a/apps/front-end/src/components/AuthRequired.tsx
+++ b/apps/front-end/src/components/AuthRequired.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from "react";
 import axios from "axios";
 
 import { useAuth } from "src/AuthContextProvider";
-import QueryBoundary from "src/components/QueryBoundary";
+import QueryBoundaryWrapper from "src/components/QueryBoundary";
 import UnauthorisedPage from "src/pages/UnauthorisedPage";
 import { DEFAULT_ERROR_MESSAGE } from "src/utility/errors/DEFAULT_ERROR_MESSAGE";
 import defaultErrorFormatters from "src/utility/errors/errorFormatters";
@@ -21,7 +21,7 @@ function AuthRequired({
   const { currentUser, currentUserLoading, currentUserError } = useAuth();
 
   return (
-    <QueryBoundary
+    <QueryBoundaryWrapper
       data={currentUser}
       isLoading={currentUserLoading}
       error={currentUserError}
@@ -40,7 +40,7 @@ function AuthRequired({
       {(user) => {
         return typeof children === "function" ? children(user) : children;
       }}
-    </QueryBoundary>
+    </QueryBoundaryWrapper>
   );
 }
 

--- a/apps/front-end/src/components/QueryBoundary.tsx
+++ b/apps/front-end/src/components/QueryBoundary.tsx
@@ -2,7 +2,7 @@ import type { QueryBoundaryDataProps, QueryBoundaryFallbackProps } from "@alexth
 
 import type { QueryBoundaryProviderProps } from "src/components/QueryBoundaryProvider";
 
-import { QueryBoundary as AlexQueryBoundary } from "@alextheman/components";
+import { QueryBoundaryWrapper as AlexQueryBoundaryWrapper } from "@alextheman/components";
 
 import ErrorMessage from "src/components/ErrorMessage";
 
@@ -13,14 +13,14 @@ export type QueryBoundaryProps<DataType> = Omit<
   Omit<QueryBoundaryFallbackProps, "errorComponent"> &
   Omit<QueryBoundaryDataProps<DataType>, "showOnError">;
 
-function QueryBoundary<DataType>({
+function QueryBoundaryWrapper<DataType>({
   children,
   codeErrorMap,
   errorFunction,
   ...queryBoundaryProps
 }: QueryBoundaryProps<DataType>) {
   return (
-    <AlexQueryBoundary
+    <AlexQueryBoundaryWrapper
       logError={import.meta.env.DEV}
       errorComponent={(error) => {
         return (
@@ -30,8 +30,8 @@ function QueryBoundary<DataType>({
       {...queryBoundaryProps}
     >
       {children}
-    </AlexQueryBoundary>
+    </AlexQueryBoundaryWrapper>
   );
 }
 
-export default QueryBoundary;
+export default QueryBoundaryWrapper;

--- a/apps/front-end/src/components/UserDropdown.tsx
+++ b/apps/front-end/src/components/UserDropdown.tsx
@@ -13,7 +13,7 @@ import Tooltip from "@mui/material/Tooltip";
 import { MdError } from "react-icons/md";
 
 import { useAuth } from "src/AuthContextProvider";
-import QueryBoundary from "src/components/QueryBoundary";
+import QueryBoundaryWrapper from "src/components/QueryBoundary";
 import formatError from "src/utility/errors/formatError";
 
 function UserDropdown() {
@@ -21,7 +21,7 @@ function UserDropdown() {
   const theme = useTheme();
 
   return (
-    <QueryBoundary
+    <QueryBoundaryWrapper
       isLoading={currentUserLoading}
       data={currentUser}
       error={currentUserError}
@@ -78,7 +78,7 @@ function UserDropdown() {
           </DropdownMenuProvider>
         );
       }}
-    </QueryBoundary>
+    </QueryBoundaryWrapper>
   );
 }
 

--- a/apps/front-end/src/hooks/createQueryBoundary.tsx
+++ b/apps/front-end/src/hooks/createQueryBoundary.tsx
@@ -1,0 +1,45 @@
+import type {
+  CreateQueryBoundaryParameters,
+  DefaultQueryBoundaryComponents,
+} from "@alextheman/components";
+
+import { createQueryBoundary as createAlexQueryBoundary } from "@alextheman/components";
+
+import QueryBoundaryDataMap from "src/components/QueryBoundaryDataMap";
+import QueryBoundaryDataRowsMap from "src/components/QueryBoundaryDataRowsMap";
+import QueryBoundaryProvider from "src/components/QueryBoundaryProvider";
+
+export interface LexiconQueryBoundaryComponents<DataType> extends Omit<
+  DefaultQueryBoundaryComponents<DataType>,
+  "Context" | "DataMap"
+> {
+  Context: typeof QueryBoundaryProvider<DataType>;
+  DataMap: typeof QueryBoundaryDataMap<DataType>;
+  DataRowsMap: typeof QueryBoundaryDataRowsMap<DataType>;
+}
+
+function createQueryBoundary<DataType>(
+  params: CreateQueryBoundaryParameters<DataType>,
+): LexiconQueryBoundaryComponents<DataType> {
+  const QueryBoundary = createAlexQueryBoundary(params);
+
+  return {
+    ...QueryBoundary,
+    Context: ({ children, ...props }) => {
+      return (
+        <QueryBoundaryProvider
+          isLoading={params.query.isLoading}
+          error={params.query.error}
+          data={params.query.data ?? params.query.dataCollection}
+          {...props}
+        >
+          {children}
+        </QueryBoundaryProvider>
+      );
+    },
+    DataMap: QueryBoundaryDataMap<DataType>,
+    DataRowsMap: QueryBoundaryDataRowsMap<DataType>,
+  };
+}
+
+export default createQueryBoundary;

--- a/apps/front-end/src/resources/Blogs/pages/Blog/index.tsx
+++ b/apps/front-end/src/resources/Blogs/pages/Blog/index.tsx
@@ -1,9 +1,10 @@
-import { Page, QueryBoundary } from "@alextheman/components";
+import { Page } from "@alextheman/components";
 import { DropdownMenuItem, DropdownMenuWrapper, InternalLink } from "@alextheman/components/v7";
 import { formatDateAndTime } from "@alextheman/utility";
 import Typography from "@mui/material/Typography";
 
 import { useAuth } from "src/AuthContextProvider";
+import QueryBoundaryWrapper from "src/components/QueryBoundary";
 import BlogContent from "src/resources/Blogs/pages/Blog/BlogContent";
 import { useBlogQuery } from "src/resources/Blogs/queries";
 
@@ -16,7 +17,7 @@ function Blog({ blogId }: BlogPageProps) {
   const { currentUser } = useAuth();
 
   return (
-    <QueryBoundary data={blog} isLoading={isPending} error={error}>
+    <QueryBoundaryWrapper data={blog} isLoading={isPending} error={error}>
       {(blog) => {
         return (
           <Page
@@ -50,7 +51,7 @@ function Blog({ blogId }: BlogPageProps) {
           </Page>
         );
       }}
-    </QueryBoundary>
+    </QueryBoundaryWrapper>
   );
 }
 

--- a/apps/front-end/src/resources/Blogs/pages/Blogs.tsx
+++ b/apps/front-end/src/resources/Blogs/pages/Blogs.tsx
@@ -1,9 +1,8 @@
 import type { BlogSummary } from "@lexicon/models";
 
-import { Page, QueryBoundaryError } from "@alextheman/components";
+import { Page } from "@alextheman/components";
 import { InternalLink } from "@alextheman/components/v7";
 import { formatDateAndTime } from "@alextheman/utility";
-import { parseBlogSummary } from "@lexicon/models";
 import Card from "@mui/material/Card";
 import Stack from "@mui/material/Stack";
 import Table from "@mui/material/Table";
@@ -15,10 +14,9 @@ import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 
 import PaginationProvider from "src/components/PaginationProvider";
-import QueryBoundaryDataRowsMap from "src/components/QueryBoundaryDataRowsMap";
-import QueryBoundaryProvider from "src/components/QueryBoundaryProvider";
 import TablePagination from "src/components/TablePagination";
 import TableSortLabel from "src/components/TableSortLabel";
+import createQueryBoundary from "src/hooks/createQueryBoundary";
 import usePagination from "src/hooks/usePagination";
 import { useBlogsQuery } from "src/resources/Blogs/queries";
 
@@ -33,12 +31,16 @@ function Blogs() {
   const { data, isPending, error } = useBlogsQuery(pagination.state.paginationSettings);
   const { rows: blogs, totalRecordCount } = data ?? {};
 
+  const QueryBoundary = createQueryBoundary({
+    query: { dataCollection: blogs, isLoading: isPending, error },
+  });
+
   return (
     <PaginationProvider pagination={pagination}>
-      <QueryBoundaryProvider data={blogs} isLoading={isPending} error={error}>
+      <QueryBoundary.Context>
         <Page title="Welcome to Lexicon!" subtitle="Take a look at some of our blogs.">
           <Stack spacing={1}>
-            <QueryBoundaryError />
+            <QueryBoundary.Error />
             <Card>
               <TableContainer>
                 <Table>
@@ -56,7 +58,7 @@ function Blogs() {
                     </TableRow>
                   </TableHead>
                   <TableBody>
-                    <QueryBoundaryDataRowsMap itemParser={parseBlogSummary} columns={3}>
+                    <QueryBoundary.DataRowsMap columns={3}>
                       {(blog) => {
                         return (
                           <TableRow>
@@ -78,7 +80,7 @@ function Blogs() {
                           </TableRow>
                         );
                       }}
-                    </QueryBoundaryDataRowsMap>
+                    </QueryBoundary.DataRowsMap>
                   </TableBody>
                   <TableFooter>
                     <TableRow>
@@ -90,7 +92,7 @@ function Blogs() {
             </Card>
           </Stack>
         </Page>
-      </QueryBoundaryProvider>
+      </QueryBoundary.Context>
     </PaginationProvider>
   );
 }

--- a/apps/front-end/src/resources/Blogs/pages/EditBlog.tsx
+++ b/apps/front-end/src/resources/Blogs/pages/EditBlog.tsx
@@ -6,7 +6,7 @@ import { useSnackbar } from "@alextheman/components";
 import { BlogState } from "@lexicon/models";
 import { useLocation } from "wouter";
 
-import QueryBoundary from "src/components/QueryBoundary";
+import QueryBoundaryWrapper from "src/components/QueryBoundary";
 import UnauthorisedPage from "src/pages/UnauthorisedPage";
 import BlogForm from "src/resources/Blogs/components/BlogForm";
 import { useBlogQuery, useEditBlogMutation } from "src/resources/Blogs/queries";
@@ -34,7 +34,7 @@ function EditBlog({ blogId, currentUser }: EditBlogProps) {
   }
 
   return (
-    <QueryBoundary data={blog} isLoading={isPending} error={error}>
+    <QueryBoundaryWrapper data={blog} isLoading={isPending} error={error}>
       {(blog) => {
         if (blog.authorId !== currentUser.id) {
           return <UnauthorisedPage />;
@@ -49,7 +49,7 @@ function EditBlog({ blogId, currentUser }: EditBlogProps) {
           />
         );
       }}
-    </QueryBoundary>
+    </QueryBoundaryWrapper>
   );
 }
 

--- a/apps/front-end/src/resources/Users/pages/EditUserProfile.tsx
+++ b/apps/front-end/src/resources/Users/pages/EditUserProfile.tsx
@@ -4,7 +4,7 @@ import { Page, useSnackbar } from "@alextheman/components";
 import { useLocation } from "wouter";
 
 import { useAuth } from "src/AuthContextProvider";
-import QueryBoundary from "src/components/QueryBoundary";
+import QueryBoundaryWrapper from "src/components/QueryBoundary";
 import UserProfileForm from "src/resources/Users/components/UserProfileForm";
 import { useUpdateUserProfileMutation } from "src/resources/Users/queries";
 import formatError from "src/utility/errors/formatError";
@@ -26,11 +26,11 @@ function EditUserProfile() {
 
   return (
     <Page title="Edit Profile" disablePadding>
-      <QueryBoundary isLoading={currentUserLoading} data={currentUser}>
+      <QueryBoundaryWrapper isLoading={currentUserLoading} data={currentUser}>
         {(user) => {
           return <UserProfileForm user={user} onSubmit={onSubmit} back={`/users/${user.id}`} />;
         }}
-      </QueryBoundary>
+      </QueryBoundaryWrapper>
     </Page>
   );
 }

--- a/apps/front-end/src/resources/Users/pages/UserProfile/index.tsx
+++ b/apps/front-end/src/resources/Users/pages/UserProfile/index.tsx
@@ -3,7 +3,7 @@ import { DropdownMenuItem, DropdownMenuWrapper, InternalLink } from "@alextheman
 import Tab from "@mui/material/Tab";
 import Tabs from "@mui/material/Tabs";
 
-import QueryBoundary from "src/components/QueryBoundary";
+import QueryBoundaryWrapper from "src/components/QueryBoundary";
 import AboutUser from "src/resources/Users/pages/UserProfile/AboutUser";
 import UserBlogs from "src/resources/Users/pages/UserProfile/UserBlogs";
 import { useUserQuery } from "src/resources/Users/queries";
@@ -19,7 +19,7 @@ function UserProfile({ userId }: UserProfileProps) {
   const [tab, setTab] = useHash<TabState>("blogs");
 
   return (
-    <QueryBoundary data={user} isLoading={isPending} error={error}>
+    <QueryBoundaryWrapper data={user} isLoading={isPending} error={error}>
       {(user) => {
         return (
           <Page
@@ -48,7 +48,7 @@ function UserProfile({ userId }: UserProfileProps) {
           </Page>
         );
       }}
-    </QueryBoundary>
+    </QueryBoundaryWrapper>
   );
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,8 +143,8 @@ importers:
   apps/front-end:
     dependencies:
       '@alextheman/components':
-        specifier: 6.18.1
-        version: 6.18.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@mui/material@9.0.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@tanstack/react-form@1.29.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-hook-form@7.75.0(react@19.2.6))(react-router-dom@7.14.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(wouter@3.9.0(react@19.2.6))
+        specifier: 6.19.0
+        version: 6.19.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@mui/material@9.0.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@tanstack/react-form@1.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-hook-form@7.75.0(react@19.2.6))(react-router-dom@7.15.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(wouter@3.9.0(react@19.2.6))
       '@emotion/react':
         specifier: 11.14.0
         version: 11.14.0(@types/react@19.2.14)(react@19.2.6)
@@ -243,8 +243,8 @@ importers:
 
 packages:
 
-  '@alextheman/components@6.18.1':
-    resolution: {integrity: sha512-FlIhVJ7OlpDaw74B3B2yLlKO7CM/XRoa+IHHWVCaj2FYGYDghBI9bDJTZOmtgypMW7kCYTN7w1/9lp2J8quSDA==}
+  '@alextheman/components@6.19.0':
+    resolution: {integrity: sha512-bpxMbXyKSJheuS6I750M9tFw62knQ3230zOMkclPicre+jGxCIzvldb75t8FcUbBZEhgGEGb/2g3WyWV9QmGtw==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       '@emotion/react': '>=11.0.0'
@@ -2160,8 +2160,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@tanstack/form-core@1.29.1':
-    resolution: {integrity: sha512-NIYPO36eEu7nSWvMpbFDQaBWyVtnH/C8fsZ3/XpJUT4uOWgmxsiUvHGbTbDNIQTXAKIkhwEl0sUrqBNn2SfUnw==}
+  '@tanstack/form-core@1.32.0':
+    resolution: {integrity: sha512-Tn5VRDSjyqjmaet2tJMuEWDRFyrCaon03vxXPlSSaiSs6C/N7lCIwGCXJbZXEUq1kTj8jYN9qyXHbsz4LQHcow==}
 
   '@tanstack/pacer-lite@0.1.1':
     resolution: {integrity: sha512-y/xtNPNt/YeyoVxE/JCx+T7yjEzpezmbb+toK8DDD1P4m7Kzs5YR956+7OKexG3f8aXgC3rLZl7b1V+yNUSy5w==}
@@ -2170,8 +2170,8 @@ packages:
   '@tanstack/query-core@5.100.10':
     resolution: {integrity: sha512-8UR0yJR+GiQ40m3lPhUr0xbfAupe6GSQiksSBSa9SM2NjezFyxXCIA69/lz8cSoNKZLrw1/PktIyQBJcVeMi3w==}
 
-  '@tanstack/react-form@1.29.1':
-    resolution: {integrity: sha512-hVHk4g0phd0HxRsv2ry6Xt8BqmalT55Q3cokhJBCC1St0hcGZhgwJJbohm9atao45BPG9e55DGvtbwExqZe35g==}
+  '@tanstack/react-form@1.32.0':
+    resolution: {integrity: sha512-6WP5SQTA6/H9crCpvpq3ZppYWqtrdE5NjOy6ebABi6uAQPqhfTzrdjS9t40mCZCFtGI5585OhJV6zBP/KN2zcw==}
     peerDependencies:
       '@tanstack/react-start': '*'
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -5145,15 +5145,15 @@ packages:
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
 
-  react-router-dom@7.14.2:
-    resolution: {integrity: sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==}
+  react-router-dom@7.15.1:
+    resolution: {integrity: sha512-AzF62gjY6U9rkMq4RfP/r2EVtQ7DMfNMjyOp/flLTCrtRylLiK4wT4pSq6O8rOXZ2eXdZYJPEYe+ifomiv+Igg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
       react-dom: '>=18'
 
-  react-router@7.14.2:
-    resolution: {integrity: sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==}
+  react-router@7.15.1:
+    resolution: {integrity: sha512-R8rl9HhgikFYoPJymnUtPXWbnDb3oget6lQnfIoupbt61aT9aOhRkDsY2XRhZRyX1Z/8a5sL74fXmFNm3NRK5A==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -6081,20 +6081,20 @@ packages:
 
 snapshots:
 
-  '@alextheman/components@6.18.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@mui/material@9.0.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@tanstack/react-form@1.29.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-hook-form@7.75.0(react@19.2.6))(react-router-dom@7.14.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(wouter@3.9.0(react@19.2.6))':
+  '@alextheman/components@6.19.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@mui/material@9.0.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@tanstack/react-form@1.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-hook-form@7.75.0(react@19.2.6))(react-router-dom@7.15.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(wouter@3.9.0(react@19.2.6))':
     dependencies:
       '@alextheman/utility': 5.18.2(zod@4.4.3)
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       '@mui/material': 9.0.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@tanstack/react-form': 1.29.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@tanstack/react-form': 1.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       common-tags: 1.8.2
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       react-hook-form: 7.75.0(react@19.2.6)
       react-icons: 5.6.0(react@19.2.6)
       react-live: 4.1.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      react-router-dom: 7.14.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react-router-dom: 7.15.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       wouter: 3.9.0(react@19.2.6)
       zod: 4.4.3
 
@@ -7746,7 +7746,7 @@ snapshots:
 
   '@tanstack/devtools-event-client@0.4.3': {}
 
-  '@tanstack/form-core@1.29.1':
+  '@tanstack/form-core@1.32.0':
     dependencies:
       '@tanstack/devtools-event-client': 0.4.3
       '@tanstack/pacer-lite': 0.1.1
@@ -7756,9 +7756,9 @@ snapshots:
 
   '@tanstack/query-core@5.100.10': {}
 
-  '@tanstack/react-form@1.29.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@tanstack/react-form@1.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@tanstack/form-core': 1.29.1
+      '@tanstack/form-core': 1.32.0
       '@tanstack/react-store': 0.9.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
     transitivePeerDependencies:
@@ -11160,13 +11160,13 @@ snapshots:
       sucrase: 3.35.1
       use-editable: 2.3.3(react@19.2.6)
 
-  react-router-dom@7.14.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  react-router-dom@7.15.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      react-router: 7.14.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react-router: 7.15.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
-  react-router@7.14.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  react-router@7.15.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       cookie: 1.1.1
       react: 19.2.6


### PR DESCRIPTION
I have recently added a createQueryBoundary function, which creates a QueryBoundary namespace where all components on it are fully typed. I have also deprecated QueryBoundary in favour of QueryBoundaryWrapper. This refactors the codebase to use the QueryBoundary namespace where appropriate and replace the previous QueryBoundary with QueryBoundaryWrapper.

# Tooling Change

This is a change to the tooling of `lexicon`. It changes the internal workings of the app and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
