### PR TITLE
Refactor the QueryBoundary.Context to not accept isLoading, error, or…

### DIFF
--- a/apps/front-end/src/hooks/createQueryBoundary.tsx
+++ b/apps/front-end/src/hooks/createQueryBoundary.tsx
@@ -2,6 +2,9 @@ import type {
   CreateQueryBoundaryParameters,
   DefaultQueryBoundaryComponents,
 } from "@alextheman/components";
+import type { JSX } from "react";
+
+import type { QueryBoundaryProviderProps } from "src/components/QueryBoundaryProvider";
 
 import { createQueryBoundary as createAlexQueryBoundary } from "@alextheman/components";
 
@@ -13,7 +16,9 @@ export interface LexiconQueryBoundaryComponents<DataType> extends Omit<
   DefaultQueryBoundaryComponents<DataType>,
   "Context" | "DataMap"
 > {
-  Context: typeof QueryBoundaryProvider<DataType>;
+  Context: (
+    props: Omit<QueryBoundaryProviderProps<DataType>, "isLoading" | "error" | "data">,
+  ) => JSX.Element;
   DataMap: typeof QueryBoundaryDataMap<DataType>;
   DataRowsMap: typeof QueryBoundaryDataRowsMap<DataType>;
 }
@@ -25,7 +30,33 @@ function createQueryBoundary<DataType>(
 
   return {
     ...QueryBoundary,
-    Context: ({ children, ...props }) => {
+    Context: ({ children, errorComponent, errorFunction, codeErrorMap, ...props }) => {
+      const query = {
+        isLoading: params.query.isLoading,
+        error: params.query.error,
+        data: params.query.data ?? params.query.dataCollection,
+      };
+
+      if (errorComponent) {
+        return (
+          <QueryBoundaryProvider {...query} errorComponent={errorComponent} {...props}>
+            {children}
+          </QueryBoundaryProvider>
+        );
+      }
+
+      if (errorFunction || codeErrorMap) {
+        return (
+          <QueryBoundaryProvider
+            {...query}
+            codeErrorMap={codeErrorMap}
+            errorFunction={errorFunction}
+          >
+            {children}
+          </QueryBoundaryProvider>
+        );
+      }
+
       return (
         <QueryBoundaryProvider
           isLoading={params.query.isLoading}


### PR DESCRIPTION
… data

They are passed into createQueryBoundary now.

Note that the whole errorComponent, errorFunction, codeErrorMap thing still lives on the Lexicon QueryBoundaryProvider for now. I would eventually like to change this so that QueryBoundaryError takes care of that, which should therefore allow the context to only take children instead.

# Refactor

This is a change to the code layout of `lexicon`. It changes how the code is presented in terms of quality and structure without changing its overall user-facing behaviour or functionality.

Please see the commits tab of this pull request for the description of changes.
