### PR TITLE
Add our own custom useQuery hook

### DIFF
--- a/apps/front-end/src/components/BackendError.tsx
+++ b/apps/front-end/src/components/BackendError.tsx
@@ -1,13 +1,7 @@
-import { useEffect } from "react";
-
-import lexiconAuthenticatedClient from "src/utility/lexiconAuthenticatedClient";
+import { useBackendErrorQuery } from "src/queries";
 
 function BackendError() {
-  useEffect(() => {
-    (async () => {
-      await lexiconAuthenticatedClient.get("/api/v1/control/be-error");
-    })();
-  }, []);
+  useBackendErrorQuery();
 
   return null;
 }

--- a/apps/front-end/src/hooks/query/helpers/retry.ts
+++ b/apps/front-end/src/hooks/query/helpers/retry.ts
@@ -1,0 +1,24 @@
+import { captureMessage } from "@sentry/react";
+
+import serverResponded from "src/utility/query/serverResponded";
+
+const MAX_FAILURES = 2;
+
+function retry(queryKey?: ReadonlyArray<unknown>) {
+  return (failureCount: number, error: unknown) => {
+    if (failureCount < MAX_FAILURES && !serverResponded(error)) {
+      return true;
+    }
+    if (
+      import.meta.env.PROD &&
+      queryKey &&
+      failureCount >= MAX_FAILURES &&
+      !serverResponded(error)
+    ) {
+      captureMessage(`Query ${queryKey.join(",")} final retry failed.`);
+    }
+    return false;
+  };
+}
+
+export default retry;

--- a/apps/front-end/src/hooks/query/helpers/throwOnError.ts
+++ b/apps/front-end/src/hooks/query/helpers/throwOnError.ts
@@ -1,0 +1,8 @@
+import isServerError from "src/utility/query/isServerError";
+import isZodError from "src/utility/query/isZodError";
+
+function throwOnError(error: unknown) {
+  return isServerError(error) || isZodError(error);
+}
+
+export default throwOnError;

--- a/apps/front-end/src/hooks/query/useMutation.ts
+++ b/apps/front-end/src/hooks/query/useMutation.ts
@@ -1,0 +1,22 @@
+// eslint-disable-next-line no-restricted-imports -- We need to import useMutation here so that the rest of the app doesn't need to.
+import { useMutation as useTanstackMutation } from "@tanstack/react-query";
+
+import retry from "src/hooks/query/helpers/retry";
+import throwOnError from "src/hooks/query/helpers/throwOnError";
+
+function useMutation<TData = unknown, TError = Error, TVariables = void, TOnMutateResult = unknown>(
+  ...[options, queryClient]: Parameters<
+    typeof useTanstackMutation<TData, TError, TVariables, TOnMutateResult>
+  >
+): ReturnType<typeof useTanstackMutation<TData, TError, TVariables, TOnMutateResult>> {
+  return useTanstackMutation<TData, TError, TVariables, TOnMutateResult>(
+    {
+      retry: retry(),
+      throwOnError,
+      ...options,
+    },
+    queryClient,
+  );
+}
+
+export default useMutation;

--- a/apps/front-end/src/hooks/query/useQuery.ts
+++ b/apps/front-end/src/hooks/query/useQuery.ts
@@ -1,0 +1,27 @@
+// eslint-disable-next-line no-restricted-imports -- We need to import useQuery here so that the rest of the app doesn't need to.
+import { useQuery as useTanstackQuery } from "@tanstack/react-query";
+
+import retry from "src/hooks/query/helpers/retry";
+import throwOnError from "src/hooks/query/helpers/throwOnError";
+
+function useQuery<
+  TQueryFnData = unknown,
+  TError = Error,
+  TData = TQueryFnData,
+  TQueryKey extends ReadonlyArray<unknown> = ReadonlyArray<unknown>,
+>(
+  ...[options, queryClient]: Parameters<
+    typeof useTanstackQuery<TQueryFnData, TError, TData, TQueryKey>
+  >
+): ReturnType<typeof useTanstackQuery<TQueryFnData, TError, TData, TQueryKey>> {
+  return useTanstackQuery<TQueryFnData, TError, TData, TQueryKey>(
+    {
+      throwOnError,
+      retry: retry(options.queryKey),
+      ...options,
+    },
+    queryClient,
+  );
+}
+
+export default useQuery;

--- a/apps/front-end/src/queries.ts
+++ b/apps/front-end/src/queries.ts
@@ -1,0 +1,12 @@
+import useQuery from "src/hooks/query/useQuery";
+import lexiconAuthenticatedClient from "src/utility/lexiconAuthenticatedClient";
+import queryKeys from "src/utility/queryKeys";
+
+export function useBackendErrorQuery() {
+  return useQuery({
+    queryKey: [queryKeys.backendError()],
+    queryFn: async () => {
+      await lexiconAuthenticatedClient.get("/api/v1/control/be-error");
+    },
+  });
+}

--- a/apps/front-end/src/resources/Blogs/queries.ts
+++ b/apps/front-end/src/resources/Blogs/queries.ts
@@ -4,9 +4,11 @@ import type { PaginatedResult, PaginationSettings } from "src/hooks/usePaginatio
 
 import { az } from "@alextheman/utility";
 import { parseBlogSummaries, parseBlogView } from "@lexicon/models";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import z from "zod";
 
+import useMutation from "src/hooks/query/useMutation";
+import useQuery from "src/hooks/query/useQuery";
 import lexiconAuthenticatedClient from "src/utility/lexiconAuthenticatedClient";
 import queryKeys, { relatedQueryKeys } from "src/utility/queryKeys";
 

--- a/apps/front-end/src/resources/Users/queries.ts
+++ b/apps/front-end/src/resources/Users/queries.ts
@@ -1,9 +1,11 @@
 import type { User, UserProfileFormOutputData } from "@lexicon/models";
 
 import { parseUser } from "@lexicon/models";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import { useLocation } from "wouter";
 
+import useMutation from "src/hooks/query/useMutation";
+import useQuery from "src/hooks/query/useQuery";
 import lexiconAuthenticatedClient from "src/utility/lexiconAuthenticatedClient";
 import queryKeys from "src/utility/queryKeys";
 

--- a/apps/front-end/src/utility/query/isServerError.ts
+++ b/apps/front-end/src/utility/query/isServerError.ts
@@ -1,0 +1,7 @@
+import axios from "axios";
+
+function isServerError(error: unknown): boolean {
+  return axios.isAxiosError(error) && (error.response?.status ?? 0) >= 500;
+}
+
+export default isServerError;

--- a/apps/front-end/src/utility/query/isZodError.ts
+++ b/apps/front-end/src/utility/query/isZodError.ts
@@ -1,0 +1,7 @@
+import { DataError } from "@alextheman/utility/v6";
+
+function isZodError(error: unknown): boolean {
+  return DataError.check(error) && error.code === "ZOD_ERROR";
+}
+
+export default isZodError;

--- a/apps/front-end/src/utility/query/serverResponded.ts
+++ b/apps/front-end/src/utility/query/serverResponded.ts
@@ -1,0 +1,7 @@
+import axios from "axios";
+
+function serverResponded(error: unknown) {
+  return axios.isAxiosError(error) && error.response !== undefined;
+}
+
+export default serverResponded;

--- a/apps/front-end/src/utility/queryKeys.ts
+++ b/apps/front-end/src/utility/queryKeys.ts
@@ -2,6 +2,9 @@ const queryKeys = {
   auth: (...args: Array<unknown>) => {
     return ["auth", ...args];
   },
+  backendError: (...args: Array<unknown>) => {
+    return ["backendError", ...args];
+  },
   users: (...args: Array<unknown>) => {
     return ["users", ...args];
   },
@@ -12,6 +15,7 @@ const queryKeys = {
 
 export const relatedQueryKeys: Record<keyof typeof queryKeys, Array<unknown>> = {
   auth: [...queryKeys.auth(), ...queryKeys.users()],
+  backendError: [...queryKeys.backendError()],
   users: [...queryKeys.users()],
   blogs: [...queryKeys.blogs()],
 };

--- a/packages/configs/src/eslint/frontend/main.ts
+++ b/packages/configs/src/eslint/frontend/main.ts
@@ -22,6 +22,13 @@ const frontendMain: Array<Linter.Config> = [
                 };
               },
             ),
+            ...["useQuery", "useMutation"].map((importName) => {
+              return {
+                importNames: [importName],
+                name: "@tanstack/react-query",
+                message: `Please use the internal \`${importName}\` from \`src/hooks/query/${importName}\` instead.`,
+              };
+            }),
           ],
         }),
       ],


### PR DESCRIPTION
This ensures that any internal server errors/parsing errors go to the error page. This tends to be the convention for most apps as these types of errors are more errors on our side so they should crash loudly.

# Tooling Change

This is a change to the tooling of `lexicon`. It changes the internal workings of the app and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
