### PR TITLE
Add a compound Tab group component

### DIFF
--- a/apps/front-end/src/groups/Tab/TabItem.tsx
+++ b/apps/front-end/src/groups/Tab/TabItem.tsx
@@ -1,0 +1,17 @@
+import type { TabProps } from "@mui/material/Tab";
+
+import Tab from "@mui/material/Tab";
+
+export interface TabItemProps<TabState extends string = string> extends Omit<TabProps, "value"> {
+  value: TabState;
+}
+
+function TabItem<TabState extends string = string>({
+  label,
+  value,
+  ...tabProps
+}: TabItemProps<TabState>) {
+  return <Tab label={label ?? value} value={value} {...tabProps} />;
+}
+
+export default TabItem;

--- a/apps/front-end/src/groups/Tab/TabList.tsx
+++ b/apps/front-end/src/groups/Tab/TabList.tsx
@@ -1,0 +1,34 @@
+import type { TabsProps } from "@mui/material/Tabs";
+import type { ReactNode } from "react";
+
+import Tabs from "@mui/material/Tabs";
+
+import { useTabContext } from "src/groups/Tab/TabProvider";
+
+interface TabListProps extends Omit<TabsProps, "value"> {
+  children: ReactNode;
+}
+
+function TabList({ children, onChange, ...tabListProps }: TabListProps) {
+  const { tab, setTab } = useTabContext();
+
+  return (
+    <Tabs
+      value={tab}
+      onChange={(event, value) => {
+        if (onChange) {
+          onChange(event, value);
+        }
+        if (event.defaultPrevented) {
+          return;
+        }
+        setTab(value);
+      }}
+      {...tabListProps}
+    >
+      {children}
+    </Tabs>
+  );
+}
+
+export default TabList;

--- a/apps/front-end/src/groups/Tab/TabPanel.tsx
+++ b/apps/front-end/src/groups/Tab/TabPanel.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from "react";
+
+import { useTabContext } from "src/groups/Tab/TabProvider";
+
+export interface TabPanelProps<TabState extends string = string> {
+  value: TabState;
+  children: ReactNode;
+}
+
+function TabPanel<TabState extends string = string>({ value, children }: TabPanelProps<TabState>) {
+  const { tab } = useTabContext();
+
+  if (value === tab) {
+    return <>{children}</>;
+  }
+
+  return null;
+}
+
+export default TabPanel;

--- a/apps/front-end/src/groups/Tab/TabProvider.tsx
+++ b/apps/front-end/src/groups/Tab/TabProvider.tsx
@@ -1,0 +1,42 @@
+import type { ContextHookOptions } from "@alextheman/components";
+import type { OptionalOnCondition } from "@alextheman/utility";
+import type { Dispatch, ReactNode, SetStateAction } from "react";
+
+import { DataError } from "@alextheman/utility/v6";
+import { createContext, useContext } from "react";
+
+export interface TabContextValue<TabState extends string = string> {
+  tab: TabState;
+  setTab: Dispatch<SetStateAction<TabState>>;
+}
+
+export interface TabProviderProps<
+  TabState extends string = string,
+> extends TabContextValue<TabState> {
+  children: ReactNode;
+}
+
+export const TabContext = createContext<TabContextValue<any> | undefined>(undefined);
+export function useTabContext<TabState extends string = string, Strict extends boolean = true>({
+  strict = true as Strict,
+}: ContextHookOptions<Strict> = {}): OptionalOnCondition<Strict, TabProviderProps<TabState>> {
+  const context = useContext(TabContext);
+  if (strict && !context) {
+    throw new DataError(
+      { strict, context },
+      "TAB_PROVIDER_NOT_FOUND",
+      "Could not find the TabProvider. Please double-check that it is present.",
+    );
+  }
+  return context as OptionalOnCondition<Strict, TabProviderProps<TabState>>;
+}
+
+function TabProvider<TabState extends string = string>({
+  children,
+  tab,
+  setTab,
+}: TabProviderProps<TabState>) {
+  return <TabContext.Provider value={{ tab, setTab }}>{children}</TabContext.Provider>;
+}
+
+export default TabProvider;

--- a/apps/front-end/src/groups/Tab/index.tsx
+++ b/apps/front-end/src/groups/Tab/index.tsx
@@ -1,0 +1,35 @@
+import type { JSX, ReactNode } from "react";
+
+import type { TabContextValue } from "src/groups/Tab/TabProvider";
+
+import TabItem from "src/groups/Tab/TabItem";
+import TabList from "src/groups/Tab/TabList";
+import TabPanel from "src/groups/Tab/TabPanel";
+import TabProvider from "src/groups/Tab/TabProvider";
+
+export interface TabComponents<TabState extends string = string> {
+  Context: (props: { children: ReactNode }) => JSX.Element;
+  List: typeof TabList;
+  Item: typeof TabItem<TabState>;
+  Panel: typeof TabPanel<TabState>;
+}
+
+function createTabGroup<TabState extends string = string>({
+  tab,
+  setTab,
+}: TabContextValue<TabState>): TabComponents<TabState> {
+  return {
+    Context: ({ children }) => {
+      return (
+        <TabProvider tab={tab} setTab={setTab}>
+          {children}
+        </TabProvider>
+      );
+    },
+    List: TabList,
+    Item: TabItem,
+    Panel: TabPanel,
+  };
+}
+
+export default createTabGroup;

--- a/apps/front-end/src/resources/Users/pages/UserProfile/index.tsx
+++ b/apps/front-end/src/resources/Users/pages/UserProfile/index.tsx
@@ -1,9 +1,8 @@
 import { Page, useHash } from "@alextheman/components";
 import { DropdownMenuItem, DropdownMenuWrapper, InternalLink } from "@alextheman/components/v7";
-import Tab from "@mui/material/Tab";
-import Tabs from "@mui/material/Tabs";
 
 import QueryBoundaryWrapper from "src/groups/QueryBoundary/QueryBoundaryWrapper";
+import createTabGroup from "src/groups/Tab";
 import AboutUser from "src/resources/Users/pages/UserProfile/AboutUser";
 import UserBlogs from "src/resources/Users/pages/UserProfile/UserBlogs";
 import { useUserQuery } from "src/resources/Users/queries";
@@ -17,38 +16,41 @@ type TabState = "blogs" | "about";
 function UserProfile({ userId }: UserProfileProps) {
   const { data: user, isPending, error } = useUserQuery(userId);
   const [tab, setTab] = useHash<TabState>("blogs");
+  const Tab = createTabGroup<TabState>({ tab, setTab });
 
   return (
-    <QueryBoundaryWrapper data={user} isLoading={isPending} error={error}>
-      {(user) => {
-        return (
-          <Page
-            title={user.displayName ?? user.username}
-            subtitle={user.username}
-            action={
-              <DropdownMenuWrapper>
-                <DropdownMenuItem component={InternalLink} to="/blogs/new">
-                  Create Blog
-                </DropdownMenuItem>
-              </DropdownMenuWrapper>
-            }
-            tabs={
-              <Tabs
-                value={tab}
-                onChange={(_, value: TabState) => {
-                  setTab(value);
-                }}
-              >
-                <Tab label="Blogs" value="blogs" />
-                <Tab label="About" value="about" />
-              </Tabs>
-            }
-          >
-            {{ blogs: <UserBlogs user={user} />, about: <AboutUser user={user} /> }[tab]}
-          </Page>
-        );
-      }}
-    </QueryBoundaryWrapper>
+    <Tab.Context>
+      <QueryBoundaryWrapper data={user} isLoading={isPending} error={error}>
+        {(user) => {
+          return (
+            <Page
+              title={user.displayName ?? user.username}
+              subtitle={user.username}
+              action={
+                <DropdownMenuWrapper>
+                  <DropdownMenuItem component={InternalLink} to="/blogs/new">
+                    Create Blog
+                  </DropdownMenuItem>
+                </DropdownMenuWrapper>
+              }
+              tabs={
+                <Tab.List>
+                  <Tab.Item label="Blogs" value="blogs" />
+                  <Tab.Item label="About" value="about" />
+                </Tab.List>
+              }
+            >
+              <Tab.Panel value="about">
+                <AboutUser user={user} />
+              </Tab.Panel>
+              <Tab.Panel value="blogs">
+                <UserBlogs user={user} />
+              </Tab.Panel>
+            </Page>
+          );
+        }}
+      </QueryBoundaryWrapper>
+    </Tab.Context>
   );
 }
 


### PR DESCRIPTION
This refactors the tab pattern to be more in-line with @mui/lab, but without actually using it because it's experimental there. It also uses separate Tab components rather than our approach of a single Tab group component, which is better because it allows type information to remain intact whereas their approach would lose type information.

# Refactor

This is a change to the code layout of `lexicon`. It changes how the code is presented in terms of quality and structure without changing its overall user-facing behaviour or functionality.

Please see the commits tab of this pull request for the description of changes.
