### PR TITLE
Use the official Docker login action

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -95,12 +95,12 @@ jobs:
           persist-credentials: false
 
       - name: Login to Docker Hub
-        env:
-          DOCKER_USERNAME: ${{ vars.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PAT }}
-        run: echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ vars.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PAT }}
 
-      - name: Push Docker image to Dockerhub
+      - name: Build and push Docker image to Docker Hub
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .


### PR DESCRIPTION
Previously we were using the CLI, which is fine but given that we are injecting secrets it is slightly risky. This changes that to use the official Docker action to login instead, which feels more official and keeps the PAt out of the direct shell environment.

# Tooling Change

This is a change to the tooling of `lexicon`. It changes the internal workings of the app and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
