### PR TITLE
Fix the UserDropdown giving an error on nullable user

### DIFF
--- a/apps/front-end/src/components/UserDropdown.tsx
+++ b/apps/front-end/src/components/UserDropdown.tsx
@@ -53,7 +53,7 @@ function UserDropdown() {
           </Box>
         );
       }}
-      nullComponent={
+      nullableComponent={
         <Button
           component={ExternalLink}
           href={`${import.meta.env.VITE_API_BASE_URL}/api/v1/auth/google?redirect=${encodeURIComponent(window.location.origin)}`}


### PR DESCRIPTION
For some reason signed-out user is considered undefined, even though I've set it to be that signed-out user is considered null? A bit weird, but this quick fix will ensure that both undefined and null are considered signed-out user. In the long-term, I need to figure out why nullComponent did not catch signed-out user.

# Bug Fix

This is a bug fix for `lexicon`. It fixes an unintended side-effect of the app.

Please see the commits tab of this pull request for the description of changes.
