### PR TITLE
Make the Lexicon title clickable on mobile

### DIFF
--- a/apps/front-end/src/components/PageWrapper/NavigationBottom.tsx
+++ b/apps/front-end/src/components/PageWrapper/NavigationBottom.tsx
@@ -1,7 +1,8 @@
 import type { ReactNode } from "react";
 
 import { ModeToggle } from "@alextheman/components";
-import { NavigationBottom as AlexNavigationBottom } from "@alextheman/components/v7";
+import { NavigationBottom as AlexNavigationBottom, InternalLink } from "@alextheman/components/v7";
+import Button from "@mui/material/Button";
 import Card from "@mui/material/Card";
 import CardHeader from "@mui/material/CardHeader";
 import Stack from "@mui/material/Stack";
@@ -19,7 +20,14 @@ function NavigationBottom({ children }: NavigationBottomProps) {
   return (
     <Stack spacing={1}>
       <Card>
-        <CardHeader title="Lexicon" action={<ModeToggle />} />
+        <CardHeader
+          title={
+            <Button component={InternalLink} to="/">
+              Lexicon
+            </Button>
+          }
+          action={<ModeToggle />}
+        />
       </Card>
       <AlexNavigationBottom
         navItems={[


### PR DESCRIPTION
This provides mobile users a nicer way to navigate back to the homepage.

# Miscellaneous

This is a general change to `lexicon` that does not fit in any of the other provided categories.

Please see the commits tab of this pull request for the description of changes.
