### PR TITLE
Start refactoring towards the new models pattern

### DIFF
--- a/apps/back-end/factory/authProviders.ts
+++ b/apps/back-end/factory/authProviders.ts
@@ -7,7 +7,7 @@ import { faker } from "@faker-js/faker";
 
 import getIdFromFactoryResource from "tests/helpers/getIdFromFactoryResource";
 
-import { insertAuthProvider } from "src/services/auth";
+import { createAuthProvider } from "src/services/auth";
 
 export type AuthProviderFactoryData = Partial<
   Omit<AuthProviderSchemaData, "userId"> & { user?: string | User }
@@ -28,7 +28,7 @@ class AuthProviderFactory {
   public async insert(data?: AuthProviderFactoryData): Promise<AuthProviderSchema> {
     const userId = await getIdFromFactoryResource<string>(data?.user, this.users);
 
-    const authProvider = await insertAuthProvider(this.context.connection, {
+    const authProvider = await createAuthProvider(this.context.connection, {
       provider: "google",
       providerUserId: faker.string.alpha(10),
       ...omitProperties(data ?? {}, "user"),

--- a/apps/back-end/factory/userSessions.ts
+++ b/apps/back-end/factory/userSessions.ts
@@ -6,7 +6,7 @@ import { omitProperties } from "@alextheman/utility";
 
 import getIdFromFactoryResource from "tests/helpers/getIdFromFactoryResource";
 
-import { insertUserSession } from "src/services/userSessions";
+import { createUserSession } from "src/services/userSessions";
 
 export type UserSessionFactoryData = Partial<
   Omit<UserSessionData, "userId"> & { user?: string | User }
@@ -27,7 +27,7 @@ class UserSessionFactory {
   public async insert(data?: UserSessionFactoryData): Promise<UserSession> {
     const userId = await getIdFromFactoryResource<string>(data?.user, this.users);
 
-    const userSession = await insertUserSession(this.context.connection, {
+    const userSession = await createUserSession(this.context.connection, {
       userId,
       ...omitProperties(data ?? {}, "user"),
     });

--- a/apps/back-end/factory/users.ts
+++ b/apps/back-end/factory/users.ts
@@ -3,7 +3,7 @@ import type FactoryContext from "factory/context";
 
 import { faker } from "@faker-js/faker";
 
-import { insertUser } from "src/services/users";
+import { insertUser } from "src/models/users";
 
 class UserFactory {
   private context: FactoryContext;

--- a/apps/back-end/src/models/auth.ts
+++ b/apps/back-end/src/models/auth.ts
@@ -1,0 +1,41 @@
+import type { AuthProvider, AuthProviderSchemaData } from "@lexicon/models";
+
+import type { Connection } from "src/database/connection";
+import type { AuthProviderSchema } from "src/database/schema";
+
+import { parseAuthProviderSchema } from "@lexicon/models";
+import { and, eq } from "drizzle-orm";
+
+import { authProvidersTable } from "src/database/schema";
+
+export interface SelectAuthProviderQuery {
+  provider?: AuthProvider;
+  providerUserId?: string;
+}
+
+export async function selectAuthProvider(
+  connection: Connection,
+  { provider, providerUserId }: SelectAuthProviderQuery,
+): Promise<AuthProviderSchema | null> {
+  const [authProvider] = await connection
+    .select()
+    .from(authProvidersTable)
+    .where(
+      and(
+        provider !== undefined ? eq(authProvidersTable.provider, provider) : undefined,
+        providerUserId !== undefined
+          ? eq(authProvidersTable.providerUserId, providerUserId)
+          : undefined,
+      ),
+    );
+
+  return authProvider ? parseAuthProviderSchema(authProvider) : null;
+}
+
+export async function insertAuthProvider(
+  connection: Connection,
+  data: AuthProviderSchemaData,
+): Promise<AuthProviderSchema> {
+  const [newProvider] = await connection.insert(authProvidersTable).values(data).returning();
+  return parseAuthProviderSchema(newProvider);
+}

--- a/apps/back-end/src/models/userSessions.ts
+++ b/apps/back-end/src/models/userSessions.ts
@@ -1,0 +1,19 @@
+import type { UserSession } from "@lexicon/models";
+
+import type { Connection } from "src/database/connection";
+
+import { parseUserSession } from "@lexicon/models";
+import { eq } from "drizzle-orm";
+
+import { userSessionsTable } from "src/database/schema";
+
+export async function selectUserSession(
+  connection: Connection,
+  sessionId: string,
+): Promise<UserSession | null> {
+  const [session] = await connection
+    .select()
+    .from(userSessionsTable)
+    .where(eq(userSessionsTable.id, sessionId));
+  return session ? parseUserSession(session) : null;
+}

--- a/apps/back-end/src/models/users.ts
+++ b/apps/back-end/src/models/users.ts
@@ -1,0 +1,36 @@
+import type { User, UserInsertData, UserUpdateData } from "@lexicon/models";
+
+import type { Connection } from "src/database/connection";
+
+import { parseUser } from "@lexicon/models";
+import { eq } from "drizzle-orm";
+
+import { usersTable } from "src/database/schema";
+
+export async function insertUser(connection: Connection, data: UserInsertData): Promise<User> {
+  const [user] = await connection
+    .insert(usersTable)
+    .values({ ...data, dateOfBirth: data.dateOfBirth?.toISOString() })
+    .returning();
+  return parseUser(user);
+}
+
+export async function selectUser(connection: Connection, userId: string): Promise<User | null> {
+  const [user] = await connection.select().from(usersTable).where(eq(usersTable.id, userId));
+
+  return user ? parseUser(user) : null;
+}
+
+export async function updateUser(
+  connection: Connection,
+  userId: string,
+  data: UserUpdateData,
+): Promise<User | null> {
+  const [user] = await connection
+    .update(usersTable)
+    .set({ ...data, dateOfBirth: data.dateOfBirth?.toISOString() })
+    .where(eq(usersTable.id, userId))
+    .returning();
+
+  return parseUser(user);
+}

--- a/apps/back-end/src/server/routes/auth.ts
+++ b/apps/back-end/src/server/routes/auth.ts
@@ -15,9 +15,10 @@ import { randomBytes } from "node:crypto";
 
 import { getGoogleConfig } from "src/auth/google";
 import { getConnection } from "src/database/connection";
-import { insertAuthProvider, selectAuthProvider } from "src/services/auth";
-import { insertUser, selectUser } from "src/services/users";
-import { expireUserSession, insertUserSession } from "src/services/userSessions";
+import { selectUser } from "src/models/users";
+import { createAuthProvider, getGoogleAuthUser } from "src/services/auth";
+import { createUser } from "src/services/users";
+import { createUserSession, expireUserSession } from "src/services/userSessions";
 import ALLOWED_ORIGINS from "src/utility/constants/ALLOWED_ORIGINS";
 import handleEndpointMiddleware from "src/utility/handleEndpointMiddleware";
 
@@ -115,31 +116,31 @@ authRouter.get(
       if (!claims?.sub || !claims?.email) {
         throw new APIError(400, "INVALID_GOOGLE_RESPONSE", "Missing required Google claims");
       }
-      const existingProvider = await selectAuthProvider(transaction, claims);
+      const existingProvider = await getGoogleAuthUser(transaction, claims);
 
       if (existingProvider) {
         const user = await selectUser(transaction, existingProvider.userId);
         assertNotNull(user);
-        const session = await insertUserSession(transaction, { userId: user.id });
+        const session = await createUserSession(transaction, { userId: user.id });
         return { user, session };
       }
 
       const [baseUsername] = claims.email.toString().split("@");
       const username = `${baseUsername}_${randomBytes(3).toString("hex")}`;
 
-      const user = await insertUser(transaction, {
+      const user = await createUser(transaction, {
         email: claims.email.toString(),
         username,
         displayName: claims.name?.toString() ?? username,
       });
 
-      await insertAuthProvider(transaction, {
+      await createAuthProvider(transaction, {
         userId: user.id,
         provider: "google",
         providerUserId: claims.sub,
       });
 
-      const session = await insertUserSession(transaction, { userId: user.id });
+      const session = await createUserSession(transaction, { userId: user.id });
       return { user, session };
     });
 

--- a/apps/back-end/src/server/routes/currentUser.ts
+++ b/apps/back-end/src/server/routes/currentUser.ts
@@ -6,8 +6,9 @@ import { parseUser } from "@lexicon/models";
 import { Router } from "express";
 
 import { getConnection } from "src/database/connection";
-import { selectUser, updateUserProfile } from "src/services/users";
-import { selectUserSession } from "src/services/userSessions";
+import { selectUser } from "src/models/users";
+import { selectUserSession } from "src/models/userSessions";
+import { editUserProfile } from "src/services/users";
 import handleEndpointMiddleware from "src/utility/handleEndpointMiddleware";
 import requireAuth from "src/utility/validators/requireAuth";
 
@@ -43,7 +44,7 @@ currentUserRouter.put(
     async (request, response) => {
       const connection = getConnection();
       const user = parseUser(request.user);
-      await updateUserProfile(connection, user.id, request.body);
+      await editUserProfile(connection, user.id, request.body);
       response.status(200).send({});
     },
   ),

--- a/apps/back-end/src/server/routes/users.ts
+++ b/apps/back-end/src/server/routes/users.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 
 import { getConnection } from "src/database/connection";
-import { selectUser } from "src/services/users";
+import { selectUser } from "src/models/users";
 import handleEndpointMiddleware from "src/utility/handleEndpointMiddleware";
 import resourceNotFoundError from "src/utility/resourceNotFoundError";
 import validateUUID from "src/utility/validators/validateUUID";

--- a/apps/back-end/src/services/auth.ts
+++ b/apps/back-end/src/services/auth.ts
@@ -4,33 +4,22 @@ import type { IDToken } from "openid-client";
 import type { Connection } from "src/database/connection";
 import type { AuthProviderSchema } from "src/database/schema";
 
-import { parseAuthProviderSchema, parseAuthProviderSchemaData } from "@lexicon/models";
-import { and, eq } from "drizzle-orm";
+import { insertAuthProvider, selectAuthProvider } from "src/models/auth";
 
-import { authProvidersTable } from "src/database/schema";
-
-export async function selectAuthProvider(
+export async function getGoogleAuthUser(
   connection: Connection,
   claims: IDToken,
 ): Promise<AuthProviderSchema | null> {
-  const [provider] = await connection
-    .select()
-    .from(authProvidersTable)
-    .where(
-      and(
-        eq(authProvidersTable.provider, "google"),
-        eq(authProvidersTable.providerUserId, claims.sub),
-      ),
-    );
-
-  return provider ? parseAuthProviderSchema(provider) : null;
+  const authProvider = await selectAuthProvider(connection, {
+    provider: "google",
+    providerUserId: claims.sub,
+  });
+  return authProvider === null ? null : authProvider;
 }
 
-export async function insertAuthProvider(
+export async function createAuthProvider(
   connection: Connection,
   data: AuthProviderSchemaData,
 ): Promise<AuthProviderSchema> {
-  const parsedData = parseAuthProviderSchemaData(data);
-  const [newProvider] = await connection.insert(authProvidersTable).values(parsedData).returning();
-  return parseAuthProviderSchema(newProvider);
+  return await insertAuthProvider(connection, data);
 }

--- a/apps/back-end/src/services/userSessions.ts
+++ b/apps/back-end/src/services/userSessions.ts
@@ -8,7 +8,7 @@ import { eq } from "drizzle-orm";
 
 import { userSessionsTable } from "src/database/schema";
 
-export async function insertUserSession(
+export async function createUserSession(
   connection: Connection,
   data: UserSessionData,
 ): Promise<UserSession> {
@@ -23,17 +23,6 @@ export async function insertUserSession(
     })
     .returning();
   return parseUserSession(session);
-}
-
-export async function selectUserSession(
-  connection: Connection,
-  sessionId: string,
-): Promise<UserSession | null> {
-  const [session] = await connection
-    .select()
-    .from(userSessionsTable)
-    .where(eq(userSessionsTable.id, sessionId));
-  return session ? parseUserSession(session) : null;
 }
 
 export async function expireUserSession(

--- a/apps/back-end/src/services/users.ts
+++ b/apps/back-end/src/services/users.ts
@@ -2,49 +2,17 @@ import type { User, UserInsertData, UserProfileData } from "@lexicon/models";
 
 import type { Connection } from "src/database/connection";
 
-import { parseUser, parseUserInsertData, parseUserProfileData } from "@lexicon/models";
-import { eq, sql } from "drizzle-orm";
+import { insertUser, updateUser } from "src/models/users";
 
-import { usersTable } from "src/database/schema";
-
-export async function insertUser(connection: Connection, data: UserInsertData): Promise<User> {
-  const parsedData = parseUserInsertData(data);
-  const [user] = await connection
-    .insert(usersTable)
-    .values({ ...parsedData, dateOfBirth: parsedData.dateOfBirth?.toISOString() })
-    .returning();
-  return parseUser(user);
+export async function createUser(connection: Connection, data: UserInsertData): Promise<User> {
+  return await insertUser(connection, data);
 }
 
-export async function selectUser(connection: Connection, userId: string): Promise<User | null> {
-  const [user] = await connection
-    .select({
-      id: usersTable.id,
-      username: usersTable.username,
-      displayName: usersTable.displayName,
-      description: usersTable.description,
-      email: usersTable.email,
-      dateOfBirth: usersTable.dateOfBirth,
-      createdAt: usersTable.createdAt,
-      updatedAt: usersTable.updatedAt,
-    })
-    .from(usersTable)
-    .where(sql`id = ${userId}`);
-
-  return user ? parseUser(user) : null;
-}
-
-export async function updateUserProfile(
+export async function editUserProfile(
   connection: Connection,
   userId: string,
   data: UserProfileData,
-): Promise<User> {
-  const parsedData = parseUserProfileData(data);
-  const [user] = await connection
-    .update(usersTable)
-    .set(parsedData)
-    .where(eq(usersTable.id, userId))
-    .returning();
-
-  return parseUser(user);
+): Promise<User | null> {
+  const user = await updateUser(connection, userId, data);
+  return user === null ? null : user;
 }

--- a/apps/back-end/src/utility/validators/requireAuth.ts
+++ b/apps/back-end/src/utility/validators/requireAuth.ts
@@ -1,8 +1,8 @@
 import { assertNotNull } from "@alextheman/utility";
 
 import { getConnection } from "src/database/connection";
-import { selectUser } from "src/services/users";
-import { selectUserSession } from "src/services/userSessions";
+import { selectUser } from "src/models/users";
+import { selectUserSession } from "src/models/userSessions";
 import authRequiredError from "src/utility/authRequiredError";
 import handleFallthroughMiddleware from "src/utility/handleFallthroughMiddleware";
 

--- a/apps/back-end/tests/server/auth.test.ts
+++ b/apps/back-end/tests/server/auth.test.ts
@@ -9,8 +9,8 @@ import { describe, expect, test, vi } from "vitest";
 import getTestFixtures from "tests/fixtures";
 
 import { usersTable } from "src/database/schema";
+import { selectUser } from "src/models/users";
 import app from "src/server/app";
-import { selectUser } from "src/services/users";
 
 vi.mock("openid-client", async () => {
   return {

--- a/apps/back-end/tests/server/blogs.test.ts
+++ b/apps/back-end/tests/server/blogs.test.ts
@@ -25,9 +25,9 @@ import { randomUUID } from "node:crypto";
 import getTestFixtures from "tests/fixtures";
 
 import { blogRevisionsTable, blogStateHistoryTable } from "src/database/schema";
+import { selectUser } from "src/models/users";
 import app from "src/server/app";
 import { getLatestBlogRevision } from "src/services/blogs";
-import { selectUser } from "src/services/users";
 
 describe("GET", () => {
   describe("/api/v1/blogs", () => {

--- a/packages/models/src/users.ts
+++ b/packages/models/src/users.ts
@@ -19,7 +19,7 @@ export const userProfileInsertSchema = z.object({
 
 export const userInsertSchema = z.object({
   id: z.uuid().optional(), // Needed for factory
-  username: z.string().max(50),
+  username: z.string().max(100),
   displayName: z.string().max(50).optional(),
   description: z.string().optional(),
   email: z.email(),
@@ -28,6 +28,7 @@ export const userInsertSchema = z.object({
 
 export type User = z.infer<typeof userSchema>;
 export type UserInsertData = z.infer<typeof userInsertSchema>;
+export type UserUpdateData = Partial<UserInsertData>;
 export type UserProfileData = z.infer<typeof userProfileInsertSchema>;
 
 export const userProfileFormSchema = z.object({


### PR DESCRIPTION
The aim here is to make regular database queries more isolated and reusable as individual units. As of now the insertBlog function inserts a blog according to the general business logic of blogs, which, while safe, makes them harder to use in things like the data factory, for example, where we may want a bit more control over the insertion order in case, for example, we want to update the ID.

The solution here is to introduce a model layer to the back-end which performs simple database queries, targeting only one table at a time. The service layer can then re-use those model functions and re-compose them how they want. This keeps the logic nice and reusable while still allowing for service functions to determine overall business logic.

# Refactor

This is a change to the code layout of `lexicon`. It changes how the code is presented in terms of quality and structure without changing its overall user-facing behaviour or functionality.

Please see the commits tab of this pull request for the description of changes.
