### PR TITLE
Externalise Zod build to get rid of tsdown warnings

### DIFF
--- a/packages/models/tsdown.config.ts
+++ b/packages/models/tsdown.config.ts
@@ -6,6 +6,9 @@ const config: UserConfig = {
   dts: true,
   clean: true,
   fixedExtension: false,
+  deps: {
+    neverBundle: ["zod"],
+  },
 };
 
 export default config;


### PR DESCRIPTION
# Tooling Change

This is a change to the tooling of `lexicon`. It changes the internal workings of the app and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
