### PR TITLE
Remove the patches folder from the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ WORKDIR /app
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json tsconfig.json ./
 COPY apps ./apps
 COPY packages ./packages
-COPY patches ./patches
 
 RUN ["pnpm", "install", "--frozen-lockfile"]
 RUN ["pnpm", "run", "build", "--ui=stream"]


### PR DESCRIPTION
It is no longer needed because we're no longer patching eslint-plugin-react.

# Tooling Change

This is a change to the tooling of `lexicon`. It changes the internal workings of the app and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
