### PR TITLE
Fix the revision ID usage in editBlog

### DIFF
--- a/apps/back-end/src/services/blogs.ts
+++ b/apps/back-end/src/services/blogs.ts
@@ -212,7 +212,7 @@ export async function editBlog(
       return null;
     }
 
-    const { revision: newRevisionId } = await insertBlogRevision(transaction, {
+    const { id: newRevisionId } = await insertBlogRevision(transaction, {
       title: data.title,
       content: data.content,
       blogId: ids.blogId,

--- a/apps/back-end/tests/server/blogs.test.ts
+++ b/apps/back-end/tests/server/blogs.test.ts
@@ -349,8 +349,8 @@ describe("PUT", () => {
       const oldRevisionNumber = await getLatestBlogRevision(connection, blog.id);
       assertNotNull(oldRevisionNumber);
 
-      const data: EditBlogData = {
-        state: BlogState.DRAFT,
+      const data: Partial<EditBlogData> = {
+        state: blog.state,
         title: "My edited blog",
         content: BlogFactory.generateEditorContent("This blog has been edited"),
       };
@@ -422,6 +422,9 @@ describe("PUT", () => {
     });
     test("Only updates the blog with the given ID", async () => {
       const { connection, factory, authenticatedClient } = await getTestFixtures();
+      await connection.execute(sql`TRUNCATE TABLE blogs RESTART IDENTITY CASCADE`);
+      await connection.execute(sql`TRUNCATE TABLE blog_revisions RESTART IDENTITY CASCADE`);
+      await connection.execute(sql`TRUNCATE TABLE blog_state_history RESTART IDENTITY CASCADE`);
 
       const firstBlog = await factory.blogs.insert();
       const secondBlog = await factory.blogs.insert();


### PR DESCRIPTION
This was pretty bad previously because it meant that after editing a blog you could potentially see other people's blog data. This fixes that so that we get the revision ID after inserting rather than the revision number.

# Bug Fix

This is a bug fix for `lexicon`. It fixes an unintended side-effect of the app.

Please see the commits tab of this pull request for the description of changes.
