### PR TITLE
Change the revision IDs to be a UUID instead of int ID

### DIFF
--- a/apps/back-end/src/database/migrations/0001_serious_hawkeye.sql
+++ b/apps/back-end/src/database/migrations/0001_serious_hawkeye.sql
@@ -1,0 +1,48 @@
+ALTER TABLE blog_revisions
+ADD COLUMN uuid_id UUID DEFAULT gen_random_uuid();
+
+ALTER TABLE blog_revisions
+DROP CONSTRAINT blog_revisions_pkey CASCADE;
+
+ALTER TABLE blog_revisions
+ADD PRIMARY KEY (uuid_id);
+
+ALTER TABLE blogs
+ADD COLUMN current_revision_uuid UUID;
+
+UPDATE blogs
+SET
+  current_revision_uuid = blog_revisions.uuid_id
+FROM
+  blog_revisions
+WHERE
+  blogs.current_revision_id = blog_revisions.id;
+
+ALTER TABLE blog_state_history
+ADD COLUMN revision_uuid UUID REFERENCES blog_revisions (uuid_id);
+
+UPDATE blog_state_history
+SET
+  revision_uuid = blog_revisions.uuid_id
+FROM
+  blog_revisions
+WHERE
+  blog_state_history.revision_id = blog_revisions.id;
+
+ALTER TABLE blog_revisions
+DROP COLUMN id;
+
+ALTER TABLE blog_revisions
+RENAME COLUMN uuid_id TO id;
+
+ALTER TABLE blog_state_history
+DROP COLUMN revision_id;
+
+ALTER TABLE blog_state_history
+RENAME COLUMN revision_uuid TO revision_id;
+
+ALTER TABLE blogs
+DROP COLUMN current_revision_id;
+
+ALTER TABLE blogs
+RENAME COLUMN current_revision_uuid TO current_revision_id;

--- a/apps/back-end/src/database/migrations/meta/0001_snapshot.json
+++ b/apps/back-end/src/database/migrations/meta/0001_snapshot.json
@@ -1,0 +1,599 @@
+{
+  "id": "a682ea80-3c84-4124-afb5-68a17e74435e",
+  "prevId": "43b7d136-df53-4b92-a668-00e6c2608b0b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth_providers": {
+      "name": "auth_providers",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "AUTH_PROVIDER_T",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_user_id": {
+          "name": "provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_providers_user_id_idx": {
+          "name": "auth_providers_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_providers_user_id_users_id_fk": {
+          "name": "auth_providers_user_id_users_id_fk",
+          "tableFrom": "auth_providers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "provider_identity_unique": {
+          "name": "provider_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "provider_user_id"
+          ]
+        },
+        "user_provider_unique": {
+          "name": "user_provider_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "provider"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blog_revisions": {
+      "name": "blog_revisions",
+      "schema": "",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "editor_id": {
+          "name": "editor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision_message": {
+          "name": "revision_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "blog_revision_per_blog_unique": {
+          "name": "blog_revision_per_blog_unique",
+          "columns": [
+            {
+              "expression": "blog_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revision",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blog_revisions_blog_id_revision_idx": {
+          "name": "blog_revisions_blog_id_revision_idx",
+          "columns": [
+            {
+              "expression": "blog_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revision",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blog_revisions_blog_id_blogs_id_fk": {
+          "name": "blog_revisions_blog_id_blogs_id_fk",
+          "tableFrom": "blog_revisions",
+          "tableTo": "blogs",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "blog_revisions_editor_id_users_id_fk": {
+          "name": "blog_revisions_editor_id_users_id_fk",
+          "tableFrom": "blog_revisions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "editor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blog_state_history": {
+      "name": "blog_state_history",
+      "schema": "",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "revision_id": {
+          "name": "revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "BLOG_STATE_T",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by_id": {
+          "name": "updated_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "blog_state_history_blog_id_idx": {
+          "name": "blog_state_history_blog_id_idx",
+          "columns": [
+            {
+              "expression": "blog_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blog_state_history_blog_id_blogs_id_fk": {
+          "name": "blog_state_history_blog_id_blogs_id_fk",
+          "tableFrom": "blog_state_history",
+          "tableTo": "blogs",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "blog_state_history_revision_id_blog_revisions_id_fk": {
+          "name": "blog_state_history_revision_id_blog_revisions_id_fk",
+          "tableFrom": "blog_state_history",
+          "tableTo": "blog_revisions",
+          "columnsFrom": [
+            "revision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "blog_state_history_updated_by_id_users_id_fk": {
+          "name": "blog_state_history_updated_by_id_users_id_fk",
+          "tableFrom": "blog_state_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blogs": {
+      "name": "blogs",
+      "schema": "",
+      "columns": {
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_revision_id": {
+          "name": "current_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "BLOG_STATE_T",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blogs_author_id_users_id_fk": {
+          "name": "blogs_author_id_users_id_fk",
+          "tableFrom": "blogs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "published_requires_timestamp": {
+          "name": "published_requires_timestamp",
+          "value": "\n          (\n            \"blogs\".\"state\" = 'published'\n          ) = (\n            \"blogs\".\"published_at\" IS NOT NULL\n          )\n        "
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_sessions": {
+      "name": "user_sessions",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_sessions_user_id_idx": {
+          "name": "user_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_sessions_expires_at_idx": {
+          "name": "user_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_sessions_user_id_users_id_fk": {
+          "name": "user_sessions_user_id_users_id_fk",
+          "tableFrom": "user_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.AUTH_PROVIDER_T": {
+      "name": "AUTH_PROVIDER_T",
+      "schema": "public",
+      "values": [
+        "google"
+      ]
+    },
+    "public.BLOG_STATE_T": {
+      "name": "BLOG_STATE_T",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published",
+        "archived"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/back-end/src/database/migrations/meta/_journal.json
+++ b/apps/back-end/src/database/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1777932070773,
       "tag": "0000_unusual_risque",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1780149171663,
+      "tag": "0001_serious_hawkeye",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/back-end/src/database/schema/blogs.ts
+++ b/apps/back-end/src/database/schema/blogs.ts
@@ -2,7 +2,6 @@ import { az } from "@alextheman/utility";
 import { BlogState } from "@lexicon/models";
 import { sql } from "drizzle-orm";
 import {
-  bigint,
   bigserial,
   check,
   index,
@@ -31,7 +30,7 @@ export const blogsTable = pgTable(
       .references(() => {
         return usersTable.id;
       }),
-    currentRevisionId: bigint("current_revision_id", { mode: "number" }),
+    currentRevisionId: uuid("current_revision_id"),
     id: uuid("id").primaryKey().defaultRandom(),
     publishedAt: timestamp("published_at", { withTimezone: true }),
     state: blogStateEnum("state").notNull(),
@@ -68,7 +67,7 @@ export const blogRevisionsTable = pgTable(
       .references(() => {
         return usersTable.id;
       }),
-    id: bigserial("id", { mode: "number" }).primaryKey(),
+    id: uuid("id").primaryKey().defaultRandom(),
     revision: integer("revision").notNull(),
     revisionMessage: text("revision_message"),
     title: varchar("title", { length: 100 }).notNull(),
@@ -90,7 +89,7 @@ export const blogStateHistoryTable = pgTable(
         return blogsTable.id;
       }),
     id: bigserial("id", { mode: "number" }).primaryKey(),
-    revisionId: bigint("revision_id", { mode: "number" })
+    revisionId: uuid("revision_id")
       .notNull()
       .references(() => {
         return blogRevisionsTable.id;

--- a/packages/models/src/blogs.ts
+++ b/packages/models/src/blogs.ts
@@ -17,7 +17,7 @@ export const blogSchema = z.object({
   id: z.uuid(),
   authorId: z.uuid(),
   state: z.enum(BlogState),
-  currentRevisionId: z.int().positive(),
+  currentRevisionId: z.uuid(),
   updatedAt: z.coerce.date(),
   publishedAt: z.coerce.date().nullable(),
 });
@@ -31,7 +31,7 @@ export function parseBlogs(input: unknown): Array<Blog> {
 }
 
 export const blogRevisionSchema = z.object({
-  id: z.int().positive(),
+  id: z.uuid(),
   editorId: z.uuid(),
   blogId: z.uuid("blog_id"),
   title: z.string().max(100),
@@ -54,7 +54,7 @@ export const blogStateHistorySchema = z.object({
   updatedById: z.uuid(),
   blogId: z.uuid(),
   state: z.enum(BlogState),
-  revisionId: z.int().positive(),
+  revisionId: z.uuid(),
   updatedAt: z.coerce.date(),
 });
 export type BlogStateHistoryRow = z.infer<typeof blogStateHistorySchema>;


### PR DESCRIPTION
This is more reliable and makes it less likely to mix up the primary key and the revision number, as both are now different data types.

# Refactor

This is a change to the code layout of `lexicon`. It changes how the code is presented in terms of quality and structure without changing its overall user-facing behaviour or functionality.

Please see the commits tab of this pull request for the description of changes.
