### PR TITLE
Skip the internal server error log if we're in test mode and we're th…

### DIFF
--- a/apps/back-end/src/server/errors/index.ts
+++ b/apps/back-end/src/server/errors/index.ts
@@ -51,7 +51,13 @@ export function handleErrors(app: Express) {
 
   app.use(
     handleErrorMiddleware((error, _request, response) => {
-      console.error(error);
+      if (
+        ENV !== "test" ||
+        (ENV === "test" &&
+          (!CodeError.check(error) || (CodeError.check(error) && error.code !== "TEST_ERROR")))
+      ) {
+        console.error(error);
+      }
       const serverError = internalServerError();
       response.status(serverError.status).send({
         error: new CodeError(serverError.code, serverError.message).toJSON(),


### PR DESCRIPTION
…rowing the test error

If we throw the test error in development or production we still want to log it. However, we do have a very specific test internal error which I don't want to be logged all the time, and so we need this to ensure that it gets silenced in testing only.

# Refactor

This is a change to the code layout of `lexicon`. It changes how the code is presented in terms of quality and structure without changing its overall user-facing behaviour or functionality.

Please see the commits tab of this pull request for the description of changes.
