### PR TITLE
Use a transaction in the POST blog endpoint

### DIFF
--- a/apps/back-end/src/server/routes/blogs.ts
+++ b/apps/back-end/src/server/routes/blogs.ts
@@ -40,12 +40,14 @@ blogsRouter
     requireAuth,
     handleEndpointMiddleware(async (request, response) => {
       const connection = getConnection();
-      const data = parseCreateBlogData(request.body);
 
-      assertNotUndefined(request.user);
+      await connection.transaction(async (transaction) => {
+        const data = parseCreateBlogData(request.body);
+        assertNotUndefined(request.user);
 
-      const { id } = await createBlog(connection, request.user.id, data);
-      response.status(201).send({ id });
+        const { id } = await createBlog(transaction, request.user.id, data);
+        response.status(201).send({ id });
+      });
     }),
   );
 


### PR DESCRIPTION
The createBlog does perform multiple inserts and stuff, and since the service no longer uses a transaction itself it should be done at the route level now.

# Bug Fix

This is a bug fix for `lexicon`. It fixes an unintended side-effect of the app.

Please see the commits tab of this pull request for the description of changes.
