### PR TITLE
Enforce back-end side that users cannot edit blogs that don't belong …

### DIFF
--- a/apps/back-end/src/server/routes/blogs.ts
+++ b/apps/back-end/src/server/routes/blogs.ts
@@ -1,4 +1,5 @@
 import { assertNotUndefined } from "@alextheman/utility";
+import { APIError } from "@alextheman/utility/v6";
 import { parseBlogFilter, parseCreateBlogData, parseEditBlogData } from "@lexicon/models";
 import { Router } from "express";
 
@@ -77,9 +78,17 @@ blogsRouter
           throw resourceNotFoundError("blog", request.params.blogId);
         }
 
-        const data = parseEditBlogData(request.body);
-
         assertNotUndefined(request.user);
+
+        if (oldBlog.authorId !== request.user.id) {
+          throw new APIError(
+            403,
+            "FORBIDDEN_ACCESS",
+            "You do not have permission to edit this blog.",
+          );
+        }
+
+        const data = parseEditBlogData(request.body);
 
         const ids = { blogId: request.params.blogId, editorId: request.user.id };
 

--- a/apps/back-end/tests/server/blogs.test.ts
+++ b/apps/back-end/tests/server/blogs.test.ts
@@ -8,7 +8,7 @@ import {
   omitProperties,
   paralleliseArrays,
 } from "@alextheman/utility";
-import { DataError } from "@alextheman/utility/v6";
+import { CodeError, DataError } from "@alextheman/utility/v6";
 import {
   BlogState,
   parseBlogSummaries,
@@ -337,9 +337,10 @@ describe("POST", () => {
 describe("PUT", () => {
   describe("/api/v1/blogs/:blogId", () => {
     test("Updates the current blog and creates a new revision", async () => {
-      const { connection, factory, authenticatedClient } = await getTestFixtures();
+      const { connection, factory, authenticatedClient, authenticatedUser } =
+        await getTestFixtures();
 
-      const blog = await factory.blogs.insert();
+      const blog = await factory.blogs.insert({ author: authenticatedUser });
       const oldRevisionNumber = await getLatestBlogVersion(connection, blog.id);
       assertNotNull(oldRevisionNumber);
 
@@ -389,9 +390,13 @@ describe("PUT", () => {
       expect(error.data.resourceId).toBe(missingId);
     });
     test("If the blog state changed, insert a new state history record", async () => {
-      const { connection, factory, authenticatedClient } = await getTestFixtures();
+      const { connection, factory, authenticatedClient, authenticatedUser } =
+        await getTestFixtures();
 
-      const blog = await factory.blogs.insert({ state: BlogState.DRAFT });
+      const blog = await factory.blogs.insert({
+        state: BlogState.DRAFT,
+        author: authenticatedUser,
+      });
 
       const data: EditBlogData = {
         state: BlogState.PUBLISHED,
@@ -415,10 +420,11 @@ describe("PUT", () => {
       expect(history[1].state).toBe(blog.state);
     });
     test("Only updates the blog with the given ID", async () => {
-      const { connection, factory, authenticatedClient } = await getTestFixtures();
+      const { connection, factory, authenticatedClient, authenticatedUser } =
+        await getTestFixtures();
 
-      const firstBlog = await factory.blogs.insert();
-      const secondBlog = await factory.blogs.insert();
+      const firstBlog = await factory.blogs.insert({ author: authenticatedUser });
+      const secondBlog = await factory.blogs.insert({ author: authenticatedUser });
 
       const [{ secondBlogTitle, secondBlogContent }] = await connection
         .select({
@@ -448,6 +454,28 @@ describe("PUT", () => {
       const secondBlogView = parseBlogView(secondBlogRequest.blog);
       expect(secondBlogView.title).toBe(secondBlogTitle);
       expect(secondBlogView.content).toEqual(secondBlogContent);
+    });
+    test("Does not allow editing of a blog that does not belong to the current user", async () => {
+      const { factory, authenticatedClient } = await getTestFixtures();
+
+      const blog = await factory.blogs.insert();
+
+      const data: EditBlogData = {
+        state: BlogState.PUBLISHED,
+        title: "My edited blog",
+        content: BlogFactory.generateEditorContent("This blog has been edited"),
+      };
+
+      const { body } = await authenticatedClient
+        .put(`/api/v1/blogs/${blog.id}`)
+        .send(data)
+        .expect(403);
+
+      const error = CodeError.expectError(() => {
+        throw body.error;
+      });
+
+      expect(error.code).toBe("FORBIDDEN_ACCESS");
     });
   });
 });

--- a/apps/front-end/src/resources/Blogs/pages/EditBlog.tsx
+++ b/apps/front-end/src/resources/Blogs/pages/EditBlog.tsx
@@ -10,12 +10,15 @@ import useLocation from "src/hooks/useLocation";
 import UnauthorisedPage from "src/pages/UnauthorisedPage";
 import BlogForm from "src/resources/Blogs/components/BlogForm";
 import { useBlogQuery, useEditBlogMutation } from "src/resources/Blogs/queries";
+import defaultErrorFormatters from "src/utility/errors/errorFormatters";
 import formatError from "src/utility/errors/formatError";
 
 interface EditBlogProps {
   blogId: string;
   currentUser: User;
 }
+
+const forbiddenMessage = "You cannot edit a blog that is not yours.";
 
 function EditBlog({ blogId, currentUser }: EditBlogProps) {
   const { data: blog, isPending, error } = useBlogQuery(blogId);
@@ -39,7 +42,13 @@ function EditBlog({ blogId, currentUser }: EditBlogProps) {
       addSnackbar("Blog saved as draft", { severity: "success" });
       setLocation(`/users/${currentUser.id}`);
     } catch (error) {
-      addSnackbar(formatError(error), { severity: "error" });
+      addSnackbar(
+        formatError(error, {
+          ...defaultErrorFormatters,
+          FORBIDDEN_ACCESS: forbiddenMessage,
+        }),
+        { severity: "error" },
+      );
     }
   }
 
@@ -47,7 +56,7 @@ function EditBlog({ blogId, currentUser }: EditBlogProps) {
     <QueryBoundaryItemWrapper data={blog} isLoading={isPending} error={error}>
       {(blog) => {
         if (blog.authorId !== currentUser.id) {
-          return <UnauthorisedPage />;
+          return <UnauthorisedPage unauthorisedMessage={forbiddenMessage} />;
         }
 
         return (


### PR DESCRIPTION
…to them

This is already enforced front-end side, but enforcing it on the back-end as well gives us an extra sense of security in case someone manages to bypass the front-end checks somehow.

# Bug Fix

This is a bug fix for `lexicon`. It fixes an unintended side-effect of the app.

Please see the commits tab of this pull request for the description of changes.
