### PR TITLE
Add the UserDropdown to the app header on mobile

### DIFF
--- a/apps/front-end/src/components/PageWrapper/NavigationBottom.tsx
+++ b/apps/front-end/src/components/PageWrapper/NavigationBottom.tsx
@@ -12,6 +12,7 @@ import Stack from "@mui/material/Stack";
 import { MdHome, MdPerson } from "react-icons/md";
 
 import { useAuth } from "src/AuthContextProvider";
+import UserDropdown from "src/components/UserDropdown";
 
 interface NavigationBottomProps {
   children: ReactNode;
@@ -29,7 +30,12 @@ function NavigationBottom({ children }: NavigationBottomProps) {
               Lexicon
             </Button>
           }
-          action={<ThemeToggle />}
+          action={
+            <Stack direction="row" spacing={2}>
+              <ThemeToggle />
+              <UserDropdown />
+            </Stack>
+          }
         />
       </Card>
       <AlexNavigationBottom


### PR DESCRIPTION
It does fit - there's not really any reason not to have it there. It will also make auth end-to-end tests easier as we can use that to verify whether we are signed in or not.

# New Feature

This is a new feature for `lexicon`. It adds new functionality to the app.

Please see the commits tab of this pull request for the description of changes.
