### PR TITLE
Add an initial end-to-end test to test blog creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
 
       - name: Upload test results to workflow output
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: ${{ !cancelled() && failure() }}
+        if: ${{ !cancelled() }}
         with:
           name: test-results
           path: apps/end-to-end/test-results/

--- a/apps/end-to-end/tests/create-blog.test.ts
+++ b/apps/end-to-end/tests/create-blog.test.ts
@@ -1,0 +1,47 @@
+import { normaliseIndents, UUID_PATTERN } from "@alextheman/utility";
+import { expect } from "@playwright/test";
+
+import test from "tests/fixtures";
+
+test.describe("Blog creation", () => {
+  test("Can create a blog and publish it immediately", async ({ authenticatedPage, baseURL }) => {
+    await authenticatedPage.goto("/blogs/new");
+    await authenticatedPage.getByLabel("Title").fill("Standards");
+    const [_, editor] = await authenticatedPage.getByRole("textbox").all();
+
+    const content = normaliseIndents`
+        Think you're ready to push and show
+        I've found problems you'd better know!
+        People think that I'm too picky
+        But I just guard the gates of quality!
+        
+        Sort those objects
+        Check that spelling
+        I just wanna get you to your best!
+        Missing symbol
+        Check that spacing
+        Put your work to the test!
+
+        I'm checking! I'm checking!
+        Checking for no mistyped things!
+        I'm checking! I'm checking!
+        Making sure your work's all in order!
+        I'm checking! I'm checking!
+        You sure this is your best work?
+        I just do this 'cause I care and
+        I have standards, you'd better have some too!
+    `;
+
+    await editor.fill(content);
+
+    const submitButton = authenticatedPage.getByRole("button", { name: "Submit" });
+    await expect(submitButton).toBeEnabled();
+    submitButton.click();
+
+    await authenticatedPage.waitForURL(RegExp(`^${baseURL}/blogs/${UUID_PATTERN}$`));
+    expect(authenticatedPage.url()).toMatch(RegExp(`^${baseURL}/blogs/${UUID_PATTERN}$`));
+    const title = authenticatedPage.getByText("Standards").first();
+    await expect(title).toBeVisible();
+    await expect(authenticatedPage.getByText(content)).toBeVisible();
+  });
+});


### PR DESCRIPTION
This just tests that we can fill in the form (and the blog can have multiple lines), and then upon submission it takes us to the blog view page.

# Tooling Change

This is a change to the tooling of `lexicon`. It changes the internal workings of the app and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
