### PR TITLE
Add an end-to-end environment

### DIFF
--- a/apps/end-to-end/playwright.config.ts
+++ b/apps/end-to-end/playwright.config.ts
@@ -38,7 +38,7 @@ const playwrightConfig: PlaywrightTestConfig = {
         use: { ...devices["Pixel 5"] },
       },
     ].map(({ name, use }) => {
-      return { name, use, dependencies: process.env.CI ? undefined : ["setup"] };
+      return { name, use, dependencies: ["setup"] };
     }),
   ],
   webServer: [

--- a/apps/end-to-end/tests/setup.ts
+++ b/apps/end-to-end/tests/setup.ts
@@ -6,7 +6,7 @@ import test from "tests/fixtures";
 
 const REPOSITORY_ROOT = path.join(process.cwd(), "..", "..");
 
-test("Reset the database", async () => {
+test(process.env.CI ? "Trivial test" : "Reset the database", async () => {
   if (!process.env.CI) {
     await execa({
       cwd: path.join(REPOSITORY_ROOT, "apps", "back-end"),


### PR DESCRIPTION
This allows us to treat development and end-to-end separately, therefore allowing us to always start from a freshly-seeded database rather than it potentially being affected by dev data.

The idea now is that the back-end test database never uses dev data and instead prefers the factory, the development database does use dev data and is meant for testing the site in a development environment, and then the end-to-end database uses dev data and is used for automated end-to-end testing, and it automatically recreates itself at the start of the test to guarantee a fresh state.

# Tooling Change

This is a change to the tooling of `lexicon`. It changes the internal workings of the app and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
