### PR TITLE
Skip the setup test at the config level rather than in setup.ts directly

### DIFF
--- a/apps/end-to-end/playwright.config.ts
+++ b/apps/end-to-end/playwright.config.ts
@@ -29,15 +29,15 @@ const playwrightConfig: PlaywrightTestConfig = {
     ...[
       {
         name: "chromium",
-        use: { ...devices["Desktop Chrome"] },
+        use: devices["Desktop Chrome"],
       },
       {
         name: "webkit",
-        use: { ...devices["Desktop Safari"] },
+        use: devices["Desktop Safari"],
       },
       {
         name: "Mobile Chrome",
-        use: { ...devices["Pixel 5"] },
+        use: devices["Pixel 5"],
       },
     ].map(({ name, use }) => {
       if (process.env.CI) {

--- a/apps/end-to-end/playwright.config.ts
+++ b/apps/end-to-end/playwright.config.ts
@@ -20,10 +20,12 @@ const playwrightConfig: PlaywrightTestConfig = {
   },
   testMatch: "**/*.test.ts",
   projects: [
-    {
-      name: "setup",
-      testMatch: "tests/setup.ts",
-    },
+    process.env.CI
+      ? null
+      : {
+          name: "setup",
+          testMatch: "tests/setup.ts",
+        },
     ...[
       {
         name: "chromium",
@@ -38,9 +40,14 @@ const playwrightConfig: PlaywrightTestConfig = {
         use: { ...devices["Pixel 5"] },
       },
     ].map(({ name, use }) => {
+      if (process.env.CI) {
+        return { name, use };
+      }
       return { name, use, dependencies: ["setup"] };
     }),
-  ],
+  ].filter((item) => {
+    return item !== null;
+  }),
   webServer: [
     {
       command: "pnpm run start-end-to-end",

--- a/apps/end-to-end/tests/setup.ts
+++ b/apps/end-to-end/tests/setup.ts
@@ -6,10 +6,8 @@ import test from "tests/fixtures";
 
 const REPOSITORY_ROOT = path.join(process.cwd(), "..", "..");
 
-test(process.env.CI ? "Trivial test" : "Reset the database", async () => {
-  if (!process.env.CI) {
-    await execa({
-      cwd: path.join(REPOSITORY_ROOT, "apps", "back-end"),
-    })`pnpm run recreate-end-to-end-db`;
-  }
+test("Reset the database", async () => {
+  await execa({
+    cwd: path.join(REPOSITORY_ROOT, "apps", "back-end"),
+  })`pnpm run recreate-end-to-end-db`;
 });


### PR DESCRIPTION
# Refactor

This is a change to the code layout of `lexicon`. It changes how the code is presented in terms of quality and structure without changing its overall user-facing behaviour or functionality.

Please see the commits tab of this pull request for the description of changes.
