### PR TITLE
Choose more distinctive ports for end-to-end

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,19 +167,19 @@ jobs:
         run: |
           touch apps/back-end/.env.end-to-end
           echo DATABASE_URL="postgresql://postgres:lexicon@localhost:5432/development?schema=public" >> apps/back-end/.env.end-to-end
-          echo PORT="8081" >> apps/back-end/.env.end-to-end
-          echo API_BASE_URL="http://localhost:8081" >> apps/back-end/.env.end-to-end
-          echo ALLOWED_ORIGINS="http://localhost:5174" >> apps/back-end/.env.end-to-end
+          echo PORT="9090" >> apps/back-end/.env.end-to-end
+          echo API_BASE_URL="http://localhost:9090" >> apps/back-end/.env.end-to-end
+          echo ALLOWED_ORIGINS="http://localhost:6173" >> apps/back-end/.env.end-to-end
 
       - name: Initialise front-end environment variables
         run: |
           touch apps/front-end/.env
-          echo VITE_API_BASE_URL="http://localhost:8081" >> apps/front-end/.env
+          echo VITE_API_BASE_URL="http://localhost:9090" >> apps/front-end/.env
 
       - name: Initialise end-to-end environment variables
         run: |
           touch apps/end-to-end/.env
-          echo API_BASE_URL="http://localhost:8081" >> apps/end-to-end/.env
+          echo API_BASE_URL="http://localhost:9090" >> apps/end-to-end/.env
 
       - name: Build packages
         run: pnpm run build

--- a/apps/end-to-end/playwright.config.ts
+++ b/apps/end-to-end/playwright.config.ts
@@ -13,7 +13,7 @@ const playwrightConfig: PlaywrightTestConfig = {
   workers: process.env.CI ? 1 : undefined,
   reporter: [["html", { open: "never" }], ["list"]],
   use: {
-    baseURL: "http://localhost:5174",
+    baseURL: "http://localhost:6173",
     trace: "on-first-retry",
     screenshot: "only-on-failure",
     video: "retain-on-failure",
@@ -52,14 +52,14 @@ const playwrightConfig: PlaywrightTestConfig = {
     {
       command: "pnpm run start-end-to-end",
       cwd: "../back-end",
-      port: 8081,
+      port: 9090,
       reuseExistingServer: !process.env.CI,
       timeout: 120000,
     },
     {
       command: "pnpm run start-end-to-end",
       cwd: "../front-end",
-      port: 5174,
+      port: 6173,
       reuseExistingServer: !process.env.CI,
       timeout: 120000,
     },

--- a/apps/front-end/package.json
+++ b/apps/front-end/package.json
@@ -27,7 +27,7 @@
     "lint-prettier-typescript": "prettier --check --parser typescript \"./**/*.{ts,tsx}\"",
     "lint-tsc": "tsc --noEmit",
     "preview": "vite preview",
-    "start-end-to-end": "NODE_ENV=end-to-end VITE_API_BASE_URL=http://localhost:8081 vite",
+    "start-end-to-end": "NODE_ENV=end-to-end VITE_API_BASE_URL=http://localhost:9090 vite",
     "update-dependencies": "pnpm update --latest && pnpm update"
   },
   "dependencies": {

--- a/apps/front-end/vite.config.ts
+++ b/apps/front-end/vite.config.ts
@@ -27,6 +27,6 @@ export default defineConfig({
     tsconfigPaths: true,
   },
   server: {
-    port: ENV === "end-to-end" ? 5174 : 5173,
+    port: ENV === "end-to-end" ? 6173 : 5173,
   },
 });


### PR DESCRIPTION
The behaviour on the front-end is often that if the port is currently unavailable for whatever reason, it will add one to the current port number. Hence there is still a chance that 5174 may not be free. This changes that so that the port numbers are more distinct and are further away in quantity from the current port, therefore reducing the possible chance of collisions.

# Tooling Change

This is a change to the tooling of `lexicon`. It changes the internal workings of the app and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
