### PR TITLE
Disable the editor based on lack of editor state

### DIFF
--- a/apps/front-end/src/resources/Blogs/components/BlogForm.tsx
+++ b/apps/front-end/src/resources/Blogs/components/BlogForm.tsx
@@ -40,7 +40,9 @@ function BlogForm({ back, defaultValues, onPublishSubmit, onDraftSubmit, loading
   const [editorState, setEditorState] = useState<SerializedEditorState | undefined>(
     typeof defaultValues.content === "string" && defaultValues.content !== ""
       ? JSON.parse(defaultValues.content)
-      : defaultValues.content,
+      : defaultValues.content === ""
+        ? undefined
+        : defaultValues.content,
   );
   const { addSnackbar } = useSnackbarContext();
 
@@ -115,7 +117,7 @@ function BlogForm({ back, defaultValues, onPublishSubmit, onDraftSubmit, loading
               <form.BackButton to={back} />
               <form.SubmitButton
                 loading={loading}
-                disabled={title === ""}
+                disabled={title === "" && editorState === undefined}
                 label="Save as Draft"
                 variant="outlined"
                 onClick={() => {
@@ -124,7 +126,7 @@ function BlogForm({ back, defaultValues, onPublishSubmit, onDraftSubmit, loading
               />
               <form.SubmitButton
                 loading={loading}
-                disabled={title === ""}
+                disabled={title === "" && editorState === undefined}
                 onClick={() => {
                   form.handleSubmit({ blogState: BlogState.PUBLISHED });
                 }}


### PR DESCRIPTION
Turns out the previous fix didn't fix the root cause of end-to-end flakiness, as it is still possible for the user to fill out the form and the editor state is still disabled for some reason. This at least fixes it so that the test continues failing early on undefined editor state rather than waiting a very long time.

# Bug Fix

This is a bug fix for `lexicon`. It fixes an unintended side-effect of the app.

Please see the commits tab of this pull request for the description of changes.
