### PR TITLE
Allow CI to use multiple workers

### DIFF
--- a/apps/end-to-end/playwright.config.ts
+++ b/apps/end-to-end/playwright.config.ts
@@ -10,7 +10,6 @@ const playwrightConfig: PlaywrightTestConfig = {
   fullyParallel: true,
   forbidOnly: Boolean(process.env.CI),
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
   reporter: [["html", { open: "never" }], ["list"]],
   use: {
     baseURL: "http://localhost:6173",


### PR DESCRIPTION
I feel like having just one worker defeats the point of end-to-end for apps. It should be able to run against multiple users as the app itself will be running against multiple users too. If it flakes we should look into it.

# Tooling Change

This is a change to the tooling of `lexicon`. It changes the internal workings of the app and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
