### PR TITLE
Scroll the editable part of the editor rather than the the entire page

### DIFF
--- a/apps/front-end/src/resources/Blogs/components/BlogEditor/ContentEditable.tsx
+++ b/apps/front-end/src/resources/Blogs/components/BlogEditor/ContentEditable.tsx
@@ -9,7 +9,7 @@ import EditorToolbar from "src/resources/Blogs/components/BlogEditor/EditorToolb
 
 function ContentEditable(props?: ContentEditableProps) {
   return (
-    <Card sx={{ minWidth: 0 }}>
+    <Card sx={{ minWidth: 0, maxHeight: 600, overflow: "hidden" }}>
       <EditorToolbar />
       <Divider />
       <CardContent
@@ -24,6 +24,8 @@ function ContentEditable(props?: ContentEditableProps) {
           whiteSpace: "pre-wrap",
           wordBreak: "break-word",
           overflowWrap: "break-word",
+          overflowY: "auto",
+          maxHeight: 550,
         }}
         {...props}
       />

--- a/apps/front-end/src/resources/Blogs/components/BlogEditor/EditorToolbar.tsx
+++ b/apps/front-end/src/resources/Blogs/components/BlogEditor/EditorToolbar.tsx
@@ -43,6 +43,8 @@ function EditorToolbar() {
     <Toolbar
       disableGutters
       sx={{
+        position: "sticky",
+        top: 0,
         minHeight: "auto",
         px: 1,
         gap: 1,


### PR DESCRIPTION
This makes it easier for the user to access the toolbar at any given point in time.

# Miscellaneous

This is a general change to `lexicon` that does not fit in any of the other provided categories.

Please see the commits tab of this pull request for the description of changes.
