### PR TITLE
Use functions to abstract away the common parsed environment variables

### DIFF
--- a/apps/back-end/drizzle.config.ts
+++ b/apps/back-end/drizzle.config.ts
@@ -1,9 +1,9 @@
-import type { Config } from "drizzle-kit";
 import dotenv from "dotenv";
+import type { Config } from "drizzle-kit";
 import path from "node:path";
-import parseEnv from "src/utility/miscellaneous/parseEnv";
+import loadEnvironment from "src/utility/env/loadEnvironment";
 
-const ENV = parseEnv(process.env.NODE_ENV ?? "development");
+const ENV = loadEnvironment();
 
 if (ENV !== "production") {
   dotenv.config({

--- a/apps/back-end/src/database/connection.ts
+++ b/apps/back-end/src/database/connection.ts
@@ -10,9 +10,9 @@ import path from "node:path";
 
 // eslint-disable-next-line @alextheman/no-namespace-imports
 import * as schema from "src/database/schema";
-import parseEnv from "src/utility/miscellaneous/parseEnv";
+import loadEnvironment from "src/utility/env/loadEnvironment";
 
-const ENV = parseEnv(process.env.NODE_ENV ?? "development");
+const ENV = loadEnvironment();
 
 const envFilePath = path.resolve(process.cwd(), `.env.${ENV}`);
 

--- a/apps/back-end/src/instrument.ts
+++ b/apps/back-end/src/instrument.ts
@@ -1,8 +1,8 @@
 import { init } from "@sentry/node";
 
-import parseEnv from "src/utility/miscellaneous/parseEnv";
+import loadEnvironment from "src/utility/env/loadEnvironment";
 
-const ENV = parseEnv(process.env.NODE_ENV ?? "development");
+const ENV = loadEnvironment();
 
 if (ENV === "production" && process.env.SENTRY_DSN) {
   init({

--- a/apps/back-end/src/server/app.ts
+++ b/apps/back-end/src/server/app.ts
@@ -1,17 +1,17 @@
-import { stringListToArray } from "@alextheman/utility";
 import cookieParser from "cookie-parser";
 import express from "express";
 
 import "src/instrument";
 import { resolveErrors } from "src/server/errors";
 import createEndpoints from "src/server/routes";
+import loadAllowedOrigins from "src/utility/env/loadAllowedOrigins";
 import setupCors from "src/utility/initialisers/setupCors";
 
 const app = express();
 
 app.use(express.json());
 
-app.use(setupCors(stringListToArray(process.env.ALLOWED_ORIGINS ?? "")));
+app.use(setupCors(loadAllowedOrigins()));
 app.use(express.json());
 app.use(cookieParser());
 

--- a/apps/back-end/src/server/errors/handleDebugLogging.ts
+++ b/apps/back-end/src/server/errors/handleDebugLogging.ts
@@ -1,9 +1,9 @@
 import { parseBoolean } from "@alextheman/utility";
 
+import loadEnvironment from "src/utility/env/loadEnvironment";
 import handleErrorMiddleware from "src/utility/handlers/handleErrorMiddleware";
-import parseEnv from "src/utility/miscellaneous/parseEnv";
 
-const ENV = parseEnv(process.env.NODE_ENV ?? "development");
+const ENV = loadEnvironment();
 const DEBUG = parseBoolean(process.env.DEBUG ?? "false");
 
 const handleDebugLogging = handleErrorMiddleware((error, _request, _response, next) => {

--- a/apps/back-end/src/server/errors/handleInternalServerErrors.ts
+++ b/apps/back-end/src/server/errors/handleInternalServerErrors.ts
@@ -1,10 +1,10 @@
 import { CodeError } from "@alextheman/utility/v6";
 
+import loadEnvironment from "src/utility/env/loadEnvironment";
 import internalServerError from "src/utility/errors/internalServerError";
 import handleErrorMiddleware from "src/utility/handlers/handleErrorMiddleware";
-import parseEnv from "src/utility/miscellaneous/parseEnv";
 
-const ENV = parseEnv(process.env.NODE_ENV ?? "development");
+const ENV = loadEnvironment();
 
 const handleInternalServerErrors = handleErrorMiddleware((error, _request, response) => {
   if (

--- a/apps/back-end/src/server/errors/index.ts
+++ b/apps/back-end/src/server/errors/index.ts
@@ -7,9 +7,9 @@ import handleClearCookies from "src/server/errors/handleClearCookies";
 import handleDebugLogging from "src/server/errors/handleDebugLogging";
 import handleInternalServerErrors from "src/server/errors/handleInternalServerErrors";
 import handleUnfoundEndpoint from "src/server/errors/handleUnfoundEndpoint";
-import parseEnv from "src/utility/miscellaneous/parseEnv";
+import loadEnvironment from "src/utility/env/loadEnvironment";
 
-const ENV = parseEnv(process.env.NODE_ENV ?? "development");
+const ENV = loadEnvironment();
 
 export function resolveErrors(app: Express) {
   if (ENV === "production") {

--- a/apps/back-end/src/server/routes/auth/getAuthGoogle.ts
+++ b/apps/back-end/src/server/routes/auth/getAuthGoogle.ts
@@ -1,7 +1,6 @@
 import type { Router } from "express";
 import type { ParamsDictionary } from "express-serve-static-core";
 
-import { stringListToArray } from "@alextheman/utility";
 import { APIError } from "@alextheman/utility/v6";
 import {
   buildAuthorizationUrl,
@@ -13,6 +12,7 @@ import {
 import { loadGoogleConfig } from "src/auth/google";
 import COOKIES from "src/server/routes/auth/helpers/COOKIES";
 import createCallbackUrl from "src/server/routes/auth/helpers/createCallbackUrl";
+import loadAllowedOrigins from "src/utility/env/loadAllowedOrigins";
 import handleEndpointMiddleware from "src/utility/handlers/handleEndpointMiddleware";
 
 function getAuthGoogle(auth: Router) {
@@ -33,7 +33,7 @@ function getAuthGoogle(auth: Router) {
           throw new APIError(400, "INVALID_REDIRECT", "Missing redirect parameter");
         }
 
-        if (!stringListToArray(process.env.ALLOWED_ORIGINS ?? "").includes(redirect)) {
+        if (!loadAllowedOrigins().includes(redirect)) {
           throw new APIError(
             403,
             "DISALLOWED_ORIGIN",

--- a/apps/back-end/src/server/routes/auth/getAuthGoogleCallback.ts
+++ b/apps/back-end/src/server/routes/auth/getAuthGoogleCallback.ts
@@ -16,10 +16,10 @@ import createAuthProvider from "src/services/auth/createAuthProvider";
 import findGoogleAuthUser from "src/services/auth/findGoogleAuthUser";
 import createUser from "src/services/users/createUser";
 import createUserSession from "src/services/userSessions/createUserSession";
+import loadEnvironment from "src/utility/env/loadEnvironment";
 import handleEndpointMiddleware from "src/utility/handlers/handleEndpointMiddleware";
-import parseEnv from "src/utility/miscellaneous/parseEnv";
 
-const ENV = parseEnv(process.env.NODE_ENV ?? "development");
+const ENV = loadEnvironment();
 
 function getAuthGoogleCallback(auth: Router) {
   auth.get(

--- a/apps/back-end/src/server/routes/auth/helpers/COOKIES.ts
+++ b/apps/back-end/src/server/routes/auth/helpers/COOKIES.ts
@@ -1,8 +1,8 @@
 import type { CookieOptions } from "express-serve-static-core";
 
-import parseEnv from "src/utility/miscellaneous/parseEnv";
+import loadEnvironment from "src/utility/env/loadEnvironment";
 
-const ENV = parseEnv(process.env.NODE_ENV ?? "development");
+const ENV = loadEnvironment();
 
 const COOKIES: CookieOptions = {
   httpOnly: true,

--- a/apps/back-end/src/utility/env/loadAllowedOrigins.ts
+++ b/apps/back-end/src/utility/env/loadAllowedOrigins.ts
@@ -1,0 +1,7 @@
+import { stringListToArray } from "@alextheman/utility";
+
+function loadAllowedOrigins(): Array<string> {
+  return stringListToArray(process.env.ALLOWED_ORIGINS ?? "");
+}
+
+export default loadAllowedOrigins;

--- a/apps/back-end/src/utility/env/loadEnvironment.ts
+++ b/apps/back-end/src/utility/env/loadEnvironment.ts
@@ -1,0 +1,9 @@
+import type { Env } from "src/utility/miscellaneous/parseEnv";
+
+import parseEnv from "src/utility/miscellaneous/parseEnv";
+
+function loadEnvironment(): Env {
+  return parseEnv(process.env.NODE_ENV ?? "development");
+}
+
+export default loadEnvironment;

--- a/apps/back-end/src/utility/handlers/allowEnvironments.ts
+++ b/apps/back-end/src/utility/handlers/allowEnvironments.ts
@@ -1,10 +1,10 @@
 import type { Env } from "src/utility/miscellaneous/parseEnv";
 
+import loadEnvironment from "src/utility/env/loadEnvironment";
 import endpointNotFoundError from "src/utility/errors/endpointNotFoundError";
 import handleFallthroughMiddleware from "src/utility/handlers/handleFallthroughMiddleware";
-import parseEnv from "src/utility/miscellaneous/parseEnv";
 
-const ENV = parseEnv(process.env.NODE_ENV ?? "development");
+const ENV = loadEnvironment();
 
 function allowEnvironments(environments: Array<Env>) {
   return handleFallthroughMiddleware((request) => {


### PR DESCRIPTION
This should help with the issue where due to the file reorganisation, the app crashes.

# Refactor

This is a change to the code layout of `lexicon`. It changes how the code is presented in terms of quality and structure without changing its overall user-facing behaviour or functionality.

Please see the commits tab of this pull request for the description of changes.
