### PR TITLE
Add an endpoint to get all blog revisions

### DIFF
--- a/apps/back-end/factory/blogRevision.ts
+++ b/apps/back-end/factory/blogRevision.ts
@@ -37,7 +37,15 @@ class BlogRevisionFactory {
     > = {},
   ): Promise<BlogRevision> {
     const editorId = await getIdFromFactoryResource<string>(data.editor, this.users);
-    const blogId = await getIdFromFactoryResource<string>(data.blog, this.blogs);
+
+    let blogId: string | Blog | undefined = data.blog;
+
+    if (blogId === undefined) {
+      blogId = (await this.blogs.insert()).blog;
+    }
+    if (typeof blogId === "object") {
+      blogId = blogId.id;
+    }
 
     const blogView = await loadBlogView(this.context.connection, blogId);
     assertNotNull(blogView);

--- a/apps/back-end/factory/blogs.ts
+++ b/apps/back-end/factory/blogs.ts
@@ -102,7 +102,7 @@ class BlogFactory {
     const blog = { ...blogModel, currentRevisionId };
 
     this.records[blog.id] = blog;
-    return blog;
+    return { blog, initialRevision: revision };
   }
 }
 

--- a/apps/back-end/src/models/blogs/selectBlogRevisions.ts
+++ b/apps/back-end/src/models/blogs/selectBlogRevisions.ts
@@ -1,0 +1,28 @@
+import type { Connection } from "src/database/connection";
+import type { BlogRevision } from "src/database/schema";
+
+import { az } from "@alextheman/utility";
+import { eq } from "drizzle-orm";
+import z from "zod";
+
+import { blogRevisionsTable } from "src/database/schema";
+
+interface SelectBlogRevisionFilters {
+  blogId: string;
+}
+
+async function selectBlogRevisions(
+  connection: Connection,
+  { blogId }: SelectBlogRevisionFilters,
+): Promise<Array<BlogRevision>> {
+  const revisions = await connection
+    .select()
+    .from(blogRevisionsTable)
+    .where(eq(blogRevisionsTable.blogId, blogId));
+
+  return revisions.map((revision) => {
+    return { ...revision, content: az.with(z.record(z.string(), z.any())).parse(revision.content) };
+  });
+}
+
+export default selectBlogRevisions;

--- a/apps/back-end/src/server/routes/blogs/getBlogRevisionByBlogId.ts
+++ b/apps/back-end/src/server/routes/blogs/getBlogRevisionByBlogId.ts
@@ -1,0 +1,32 @@
+import type { Router } from "express";
+
+import { getConnection } from "src/database/connection";
+import selectBlog from "src/models/blogs/selectBlog";
+import loadBlogRevisions from "src/services/blogs/loadBlogRevisions";
+import resourceNotFoundError from "src/utility/errors/resourceNotFoundError";
+import handleEndpointMiddleware from "src/utility/handlers/handleEndpointMiddleware";
+import requireAuth from "src/utility/handlers/requireAuth";
+import validateUUID from "src/utility/handlers/validateUUID";
+
+function getBlogRevisionByBlogId(blogs: Router) {
+  blogs.param("blogId", validateUUID).get<{ blogId: string }>(
+    "/:blogId/revisions",
+    requireAuth,
+    handleEndpointMiddleware(async (request, response) => {
+      const connection = getConnection();
+      const { blogId } = request.params;
+
+      const blog = await selectBlog(connection, blogId);
+
+      if (blog === null) {
+        throw resourceNotFoundError("blog", blogId);
+      }
+
+      const revisions = await loadBlogRevisions(connection, { blogId });
+
+      response.status(200).send({ revisions });
+    }),
+  );
+}
+
+export default getBlogRevisionByBlogId;

--- a/apps/back-end/src/server/routes/blogs/index.ts
+++ b/apps/back-end/src/server/routes/blogs/index.ts
@@ -1,6 +1,7 @@
 import type { Router } from "express";
 
 import getBlogById from "src/server/routes/blogs/getBlogById";
+import getBlogRevisionByBlogId from "src/server/routes/blogs/getBlogRevisionByBlogId";
 import getBlogs from "src/server/routes/blogs/getBlogs";
 import postBlogs from "src/server/routes/blogs/postBlogs";
 import putBlogById from "src/server/routes/blogs/putBlogById";
@@ -9,6 +10,7 @@ import registerEndpoints from "src/utility/initialisers/registerEndpoints";
 function initialiseBlogsRouter(router: Router) {
   registerEndpoints(router, {
     getBlogs,
+    getBlogRevisionByBlogId,
     getBlogById,
     postBlogs,
     putBlogById,

--- a/apps/back-end/src/services/blogs/loadBlogRevisions.ts
+++ b/apps/back-end/src/services/blogs/loadBlogRevisions.ts
@@ -1,0 +1,25 @@
+import type { BlogRevision } from "@lexicon/models";
+
+import type { Connection } from "src/database/connection";
+
+import { az } from "@alextheman/utility";
+import z from "zod";
+
+import selectBlogRevisions from "src/models/blogs/selectBlogRevisions";
+
+export interface LoadBlogRevisionsFilters {
+  blogId: string;
+}
+
+async function loadBlogRevisions(
+  connection: Connection,
+  filters: LoadBlogRevisionsFilters,
+): Promise<Array<BlogRevision>> {
+  const revisions = await selectBlogRevisions(connection, filters);
+
+  return revisions.map((revision) => {
+    return { ...revision, content: az.with(z.record(z.string(), z.any())).parse(revision.content) };
+  });
+}
+
+export default loadBlogRevisions;

--- a/apps/back-end/tests/isolation.test.ts
+++ b/apps/back-end/tests/isolation.test.ts
@@ -10,7 +10,8 @@ describe("Isolated test setup", () => {
 
     const blogs = await fillArray(
       async () => {
-        return await factory.blogs.insert();
+        const { blog } = await factory.blogs.insert();
+        return blog;
       },
       10,
       { sequential: true },
@@ -34,7 +35,8 @@ describe("Isolated test setup", () => {
 
     const blogs = await fillArray(
       async () => {
-        return await factory.blogs.insert();
+        const { blog } = await factory.blogs.insert();
+        return blog;
       },
       10,
       { sequential: true },

--- a/apps/back-end/tests/server/blogs/getBlogById.test.ts
+++ b/apps/back-end/tests/server/blogs/getBlogById.test.ts
@@ -15,7 +15,7 @@ describe("GET /api/v1/blogs/<blogId>", () => {
   test("Returns the blog with the given blog ID", async () => {
     const { connection, factory, authenticatedClient } = await getTestFixtures();
 
-    const blog = await factory.blogs.insert();
+    const { blog } = await factory.blogs.insert();
 
     const { body } = await authenticatedClient.get(`/api/v1/blogs/${blog.id}`).expect(200);
 

--- a/apps/back-end/tests/server/blogs/getBlogRevisionsByBlogId.test.ts
+++ b/apps/back-end/tests/server/blogs/getBlogRevisionsByBlogId.test.ts
@@ -1,0 +1,56 @@
+import { assertNotUndefined, az, fillArray } from "@alextheman/utility";
+import { DataError } from "@alextheman/utility/v6";
+import { parseBlogRevisionHistory } from "@lexicon/models";
+import { describe, expect, test } from "vitest";
+import z from "zod";
+
+import getTestFixtures from "tests/fixtures";
+
+describe("GET /api/v1/blogs/<blogId>/revisions", () => {
+  test("Gets all the blog revisions for the chosen blog", async () => {
+    const { factory, authenticatedClient, authenticatedUser } = await getTestFixtures();
+
+    const { blog, initialRevision } = await factory.blogs.insert({ author: authenticatedUser });
+    const blogRevisions = await fillArray(
+      async () => {
+        return await factory.blogRevisions.insert({ blog, editor: authenticatedUser });
+      },
+      10,
+      { sequential: true },
+    );
+    blogRevisions.push({
+      ...initialRevision,
+      content: az.with(z.record(z.string(), z.any())).parse(initialRevision.content),
+    });
+
+    const factoryRevisionIds = blogRevisions.map((revision) => {
+      return revision.id;
+    });
+
+    const { body } = await authenticatedClient
+      .get(`/api/v1/blogs/${blog.id}/revisions`)
+      .expect(200);
+
+    const revisions = parseBlogRevisionHistory(body.revisions);
+    // One more than the generated 10 because of the initially created revision from the blogs factory
+    expect(revisions.length).toBe(11);
+
+    for (const revision of revisions) {
+      if (factoryRevisionIds.includes(revision.id)) {
+        const factoryRevision = blogRevisions.find((factoryRevision) => {
+          return factoryRevision.id === revision.id;
+        });
+
+        assertNotUndefined(factoryRevision);
+
+        expect(revision).toMatchObject(factoryRevision);
+      } else {
+        throw new DataError(
+          { factoryRevisionIds, missingId: revision.id },
+          "REVISION_NOT_FOUND",
+          "Could not find the blog revision",
+        );
+      }
+    }
+  });
+});

--- a/apps/back-end/tests/server/blogs/getBlogs.test.ts
+++ b/apps/back-end/tests/server/blogs/getBlogs.test.ts
@@ -25,7 +25,8 @@ describe("GET /api/v1/blogs", () => {
 
     const blogs = await fillArray(
       async () => {
-        return await factory.blogs.insert();
+        const { blog } = await factory.blogs.insert();
+        return blog;
       },
       10,
       { sequential: true },
@@ -84,7 +85,8 @@ describe("GET /api/v1/blogs", () => {
     const blogs = (
       await fillArray(
         async () => {
-          return await factory.blogs.insert({ author, state: BlogState.PUBLISHED });
+          const { blog } = await factory.blogs.insert({ author, state: BlogState.PUBLISHED });
+          return blog;
         },
         10,
         { sequential: true },
@@ -130,7 +132,8 @@ describe("GET /api/v1/blogs", () => {
 
     await fillArray(
       async () => {
-        return await factory.blogs.insert({ author });
+        const { blog } = await factory.blogs.insert({ author });
+        return blog;
       },
       5,
       { sequential: true },

--- a/apps/back-end/tests/server/blogs/putBlogById.test.ts
+++ b/apps/back-end/tests/server/blogs/putBlogById.test.ts
@@ -18,7 +18,7 @@ describe("PUT /api/v1/blogs/<blogId>", () => {
   test("Updates the current blog and creates a new revision", async () => {
     const { connection, factory, authenticatedClient, authenticatedUser } = await getTestFixtures();
 
-    const blog = await factory.blogs.insert({ author: authenticatedUser });
+    const { blog } = await factory.blogs.insert({ author: authenticatedUser });
     const oldRevisionNumber = await findLatestBlogVersion(connection, blog.id);
     assertNotNull(oldRevisionNumber);
 
@@ -70,7 +70,7 @@ describe("PUT /api/v1/blogs/<blogId>", () => {
   test("If the blog state changed, insert a new state history record", async () => {
     const { connection, factory, authenticatedClient, authenticatedUser } = await getTestFixtures();
 
-    const blog = await factory.blogs.insert({
+    const { blog } = await factory.blogs.insert({
       state: BlogState.DRAFT,
       author: authenticatedUser,
     });
@@ -99,8 +99,8 @@ describe("PUT /api/v1/blogs/<blogId>", () => {
   test("Only updates the blog with the given ID", async () => {
     const { connection, factory, authenticatedClient, authenticatedUser } = await getTestFixtures();
 
-    const firstBlog = await factory.blogs.insert({ author: authenticatedUser });
-    const secondBlog = await factory.blogs.insert({ author: authenticatedUser });
+    const { blog: firstBlog } = await factory.blogs.insert({ author: authenticatedUser });
+    const { blog: secondBlog } = await factory.blogs.insert({ author: authenticatedUser });
 
     const [{ secondBlogTitle, secondBlogContent }] = await connection
       .select({
@@ -134,7 +134,7 @@ describe("PUT /api/v1/blogs/<blogId>", () => {
   test("Does not allow editing of a blog that does not belong to the current user", async () => {
     const { factory, authenticatedClient } = await getTestFixtures();
 
-    const blog = await factory.blogs.insert();
+    const { blog } = await factory.blogs.insert();
 
     const data: EditBlogData = {
       state: BlogState.PUBLISHED,


### PR DESCRIPTION
Also note that I had to amend the blog factory's return so that it returns both the created blog and the initial revision. The blog factory always creates a blog and an intial revision, but we can't use the blog revision factory in the blog factory because the revision factory needs the blog factory. As such, we need to return the initial revision so that we don't lose access to it.

# New Feature

This is a new feature for `lexicon`. It adds new functionality to the app.

Please see the commits tab of this pull request for the description of changes.
