### PR TITLE
Display the error messages from the query on Blog revisions page

### DIFF
--- a/apps/front-end/src/resources/Blogs/pages/BlogRevisions.tsx
+++ b/apps/front-end/src/resources/Blogs/pages/BlogRevisions.tsx
@@ -39,6 +39,8 @@ function BlogRevisions({ blogId }: BlogRevisionsProps) {
         </QueryBoundaryBlog.Data>
       }
     >
+      <QueryBoundaryBlog.Error />
+      <QueryBoundaryRevisions.Error />
       <QueryBoundaryBlog.Data>
         {(blog) => {
           return (


### PR DESCRIPTION
I initially forgot about that, probably because the context would've made this not work properly. But now the group is fully responsible for the query data, it is now possible to do this and have the errors show next to each other this way.

# New Feature

This is a new feature for `lexicon`. It adds new functionality to the app.

Please see the commits tab of this pull request for the description of changes.