### PR TITLE
Only allow the end-to-end environment to access the end-to-end login …

### DIFF
--- a/apps/back-end/src/server/routes/auth/postAuthEndToEnd.ts
+++ b/apps/back-end/src/server/routes/auth/postAuthEndToEnd.ts
@@ -13,7 +13,7 @@ import handleEndpointMiddleware from "src/utility/handlers/handleEndpointMiddlew
 function postAuthEndToEnd(auth: Router) {
   auth.post(
     "/end-to-end",
-    allowEnvironments(["development", "end-to-end"]),
+    allowEnvironments(["end-to-end"]),
     handleEndpointMiddleware(async (request, response) => {
       const COOKIES = loadCookies();
       const connection = getConnection();


### PR DESCRIPTION
…endpoint.

If NODE_ENV and the derived ENV are being correctly configured, this should pass end-to-end, otherwise it won't. If it doesn't pass, it suggests the issue is within the code, otherwise it may be an Infrastructure issue.