### PR TITLE
Add a warning banner to notify users about the auth issue

### DIFF
--- a/apps/front-end/src/components/PageWrapper/Banner.tsx
+++ b/apps/front-end/src/components/PageWrapper/Banner.tsx
@@ -1,0 +1,12 @@
+import Alert from "@mui/material/Alert";
+
+function Banner() {
+  return (
+    <Alert severity="warning">
+      There is currently a known issue with Google authentication at the moment preventing users
+      from signing in. We are currently looking into the issue and hope to get it resolved soon.
+    </Alert>
+  );
+}
+
+export default Banner;

--- a/apps/front-end/src/components/PageWrapper/NavigationBottom.tsx
+++ b/apps/front-end/src/components/PageWrapper/NavigationBottom.tsx
@@ -12,6 +12,7 @@ import Stack from "@mui/material/Stack";
 import { MdHome, MdPerson } from "react-icons/md";
 
 import { useAuth } from "src/AuthContextProvider";
+import Banner from "src/components/PageWrapper/Banner";
 import UserDropdown from "src/components/UserDropdown";
 
 interface NavigationBottomProps {
@@ -52,6 +53,7 @@ function NavigationBottom({ children }: NavigationBottomProps) {
           },
         ]}
       >
+        <Banner />
         {children}
       </AlexNavigationBottom>
     </Stack>

--- a/apps/front-end/src/components/PageWrapper/NavigationDrawer.tsx
+++ b/apps/front-end/src/components/PageWrapper/NavigationDrawer.tsx
@@ -4,6 +4,7 @@ import { NavigationDrawer as AlexNavigationDrawer } from "@alextheman/components
 import { ThemeToggle } from "@alextheman/components/theme";
 import Stack from "@mui/material/Stack";
 
+import Banner from "src/components/PageWrapper/Banner";
 import UserDropdown from "src/components/UserDropdown";
 
 interface NavigationDrawerProps {
@@ -32,6 +33,7 @@ function NavigationDrawer({ children }: NavigationDrawerProps) {
         },
       ]}
     >
+      <Banner />
       {children}
     </AlexNavigationDrawer>
   );


### PR DESCRIPTION
I am in such a bad position to debug it - it is coming to midnight, auth is down, and I can't access HCP Terraform to inspect the infrastructure variables... This is painful!

# Miscellaneous

This is a general change to `lexicon` that does not fit in any of the other provided categories.

Please see the commits tab of this pull request for the description of changes.
