### PR TITLE
Refactor the blogs and blogRevisions factory

### DIFF
--- a/apps/back-end/dev/data.ts
+++ b/apps/back-end/dev/data.ts
@@ -30,7 +30,7 @@ import users from "dev/fixtures/users.json" with { type: "json" };
     }
 
     for (const blog of blogs) {
-      await factory.blogs.insert({
+      await factory.blogs.insertWithRevision({
         ...omitProperties(blog, ["authorId", "content", "state"]),
         author: blog.authorId,
         state: az

--- a/apps/back-end/factory/blogRevision.ts
+++ b/apps/back-end/factory/blogRevision.ts
@@ -1,16 +1,19 @@
-import type { Blog, BlogRevision, User } from "@lexicon/models";
-import type BlogFactory from "factory/blogs";
+import type { BlogRevision, User } from "@lexicon/models";
 import type FactoryContext from "factory/context";
 import type UserFactory from "factory/users";
 
-import type { BlogRevisionInsert } from "src/database/schema";
+import type { Blog, BlogRevisionInsert } from "src/database/schema";
 
-import { assertNotNull, omitProperties } from "@alextheman/utility";
-import { parseBlogRevision } from "@lexicon/models";
+import { assertNotNull, az, getRandomNumber, omitProperties } from "@alextheman/utility";
+import { faker } from "@faker-js/faker";
+import BlogFactory from "factory/blogs";
+import z from "zod";
 
 import getIdFromFactoryResource from "tests/helpers/getIdFromFactoryResource";
 
 import insertBlogRevision from "src/models/blogs/insertBlogRevision";
+import selectBlog from "src/models/blogs/selectBlog";
+import updateBlog from "src/models/blogs/updateBlog";
 import findLatestBlogVersion from "src/services/blogs/findLatestBlogRevision";
 import loadBlogView from "src/services/blogs/loadBlogView";
 
@@ -36,35 +39,40 @@ class BlogRevisionFactory {
       }
     > = {},
   ): Promise<BlogRevision> {
-    const editorId = await getIdFromFactoryResource<string>(data.editor, this.users);
+    const blogId = await getIdFromFactoryResource<string>(data.blog, this.blogs);
 
-    let blogId: string | Blog | undefined = data.blog;
-
-    if (blogId === undefined) {
-      blogId = (await this.blogs.insert()).blog;
-    }
-    if (typeof blogId === "object") {
-      blogId = blogId.id;
-    }
-
+    const blog = await selectBlog(this.context.connection, blogId);
+    assertNotNull(blog);
     const blogView = await loadBlogView(this.context.connection, blogId);
-    assertNotNull(blogView);
-    const latestVersion = await findLatestBlogVersion(this.context.connection, blogId);
-    assertNotNull(latestVersion);
+
+    const editorId =
+      data.editor !== undefined
+        ? await getIdFromFactoryResource<string>(data.editor, this.users)
+        : blog.authorId;
+
+    const latestVersion = (await findLatestBlogVersion(this.context.connection, blogId)) ?? 0;
 
     const blogRevisionTemplate: BlogRevisionInsert = {
       editorId,
       blogId,
-      title: data.title ?? blogView.title,
-      content: data.content ?? blogView.content,
+      title: data.title ?? blogView?.title ?? faker.book.title(),
+      content:
+        data.content ??
+        blogView?.content ??
+        BlogFactory.generateEditorContent(faker.lorem.sentences(getRandomNumber(0, 5))),
       version: data.version ?? latestVersion + 1,
       ...omitProperties(data, ["editor", "blog"]),
     };
-    const createdRevision = await insertBlogRevision(this.context.connection, blogRevisionTemplate);
-    const revision = parseBlogRevision(createdRevision);
+    const revision = await insertBlogRevision(this.context.connection, blogRevisionTemplate);
+    await updateBlog(this.context.connection, blogId, { currentRevisionId: revision.id });
 
-    this.records[revision.id] = revision;
-    return revision;
+    const newRevision = {
+      ...revision,
+      content: az.with(z.record(z.string(), z.any())).parse(revision.content),
+    };
+
+    this.records[newRevision.id] = newRevision;
+    return newRevision;
   }
 }
 

--- a/apps/back-end/factory/blogs.ts
+++ b/apps/back-end/factory/blogs.ts
@@ -1,6 +1,8 @@
-import type { Blog, CreateBlogData, User } from "@lexicon/models";
+import type { CreateBlogData, User } from "@lexicon/models";
 import type FactoryContext from "factory/context";
 import type UserFactory from "factory/users";
+
+import type { Blog, BlogInsert, BlogRevision } from "src/database/schema";
 
 import { assertNotNull, getRandomNumber, omitProperties } from "@alextheman/utility";
 import { faker } from "@faker-js/faker";
@@ -13,6 +15,10 @@ import insertBlogRevision from "src/models/blogs/insertBlogRevision";
 import insertBlogStateHistory from "src/models/blogs/insertBlogStateHistory";
 import selectBlog from "src/models/blogs/selectBlog";
 import updateBlog from "src/models/blogs/updateBlog";
+
+type BlogFactoryData<InsertType extends object = Record<string, unknown>> = Partial<
+  Omit<InsertType, "authorId"> & { id: string; author: string | User }
+>;
 
 class BlogFactory {
   private context: FactoryContext;
@@ -60,9 +66,27 @@ class BlogFactory {
     };
   }
 
-  public async insert(
-    data: Partial<Omit<CreateBlogData, "authorId"> & { id: string; author: string | User }> = {},
-  ) {
+  public async insert(data: BlogFactoryData<BlogInsert> = {}): Promise<Blog> {
+    const authorId = await getIdFromFactoryResource<string>(data.author, this.users);
+    const blogTemplate: BlogInsert = {
+      authorId,
+      state: BlogState.DRAFT,
+      ...omitProperties(data, "author"),
+    };
+    const today = new Date();
+
+    const blog = await insertBlog(this.context.connection, {
+      ...blogTemplate,
+      authorId,
+      publishedAt: blogTemplate.state === BlogState.PUBLISHED ? today : null,
+      updatedAt: today,
+    });
+
+    return blog;
+  }
+  public async insertWithRevision(
+    data: BlogFactoryData<CreateBlogData> = {},
+  ): Promise<{ blog: Blog; revision: BlogRevision }> {
     const authorId = await getIdFromFactoryResource<string>(data.author, this.users);
     const blogTemplate: CreateBlogData = {
       title: faker.music.songName(),
@@ -102,7 +126,7 @@ class BlogFactory {
     const blog = { ...blogModel, currentRevisionId };
 
     this.records[blog.id] = blog;
-    return { blog, initialRevision: revision };
+    return { blog, revision };
   }
 }
 

--- a/apps/back-end/src/services/blogs/findLatestBlogRevision.ts
+++ b/apps/back-end/src/services/blogs/findLatestBlogRevision.ts
@@ -1,8 +1,6 @@
 import type { Connection } from "src/database/connection";
 
-import { az } from "@alextheman/utility";
 import { desc, eq } from "drizzle-orm";
-import z from "zod";
 
 import { blogRevisionsTable } from "src/database/schema";
 
@@ -10,12 +8,12 @@ async function findLatestBlogVersion(
   connection: Connection,
   blogId: string,
 ): Promise<number | null> {
-  const [{ version }] = await connection
+  const [revision] = await connection
     .select({ version: blogRevisionsTable.version })
     .from(blogRevisionsTable)
     .where(eq(blogRevisionsTable.blogId, blogId))
     .orderBy(desc(blogRevisionsTable.version));
-  return version === undefined || version === null ? null : az.with(z.int()).parse(version);
+  return revision?.version === undefined || revision?.version === null ? null : revision.version;
 }
 
 export default findLatestBlogVersion;

--- a/apps/back-end/tests/isolation.test.ts
+++ b/apps/back-end/tests/isolation.test.ts
@@ -10,7 +10,7 @@ describe("Isolated test setup", () => {
 
     const blogs = await fillArray(
       async () => {
-        const { blog } = await factory.blogs.insert();
+        const { blog } = await factory.blogs.insertWithRevision();
         return blog;
       },
       10,
@@ -35,7 +35,7 @@ describe("Isolated test setup", () => {
 
     const blogs = await fillArray(
       async () => {
-        const { blog } = await factory.blogs.insert();
+        const { blog } = await factory.blogs.insertWithRevision();
         return blog;
       },
       10,

--- a/apps/back-end/tests/server/blogs/getBlogById.test.ts
+++ b/apps/back-end/tests/server/blogs/getBlogById.test.ts
@@ -1,21 +1,19 @@
 import { assertNotNull, omitProperties } from "@alextheman/utility";
 import { DataError } from "@alextheman/utility/v6";
 import { parseBlogView } from "@lexicon/models";
-import { eq } from "drizzle-orm";
 import { describe, expect, test } from "vitest";
 
 import { randomUUID } from "node:crypto";
 
 import getTestFixtures from "tests/fixtures";
 
-import { blogRevisionsTable } from "src/database/schema";
 import selectUser from "src/models/users/selectUser";
 
 describe("GET /api/v1/blogs/<blogId>", () => {
   test("Returns the blog with the given blog ID", async () => {
     const { connection, factory, authenticatedClient } = await getTestFixtures();
 
-    const { blog } = await factory.blogs.insert();
+    const { blog, revision } = await factory.blogs.insertWithRevision();
 
     const { body } = await authenticatedClient.get(`/api/v1/blogs/${blog.id}`).expect(200);
 
@@ -26,14 +24,6 @@ describe("GET /api/v1/blogs/<blogId>", () => {
     assertNotNull(user);
     expect(blogView.authorDisplayName).toBe(user.displayName);
     expect(blogView.authorUsername).toBe(user.username);
-
-    const [revision] = await connection
-      .select({
-        title: blogRevisionsTable.title,
-        content: blogRevisionsTable.content,
-      })
-      .from(blogRevisionsTable)
-      .where(eq(blogRevisionsTable.id, blog.currentRevisionId));
 
     assertNotNull(revision);
 

--- a/apps/back-end/tests/server/blogs/getBlogRevisionsByBlogId.test.ts
+++ b/apps/back-end/tests/server/blogs/getBlogRevisionsByBlogId.test.ts
@@ -1,11 +1,10 @@
 import type { ResourceNotFoundErrorPayload } from "src/utility/errors/resourceNotFoundError";
 
-import { assertNotUndefined, az, fillArray } from "@alextheman/utility";
+import { assertNotUndefined, fillArray } from "@alextheman/utility";
 import { CodeError, DataError } from "@alextheman/utility/v6";
 import { parseBlogRevisionHistory } from "@lexicon/models";
 import request from "supertest";
 import { describe, expect, test } from "vitest";
-import z from "zod";
 
 import { randomUUID } from "node:crypto";
 
@@ -17,7 +16,7 @@ describe("GET /api/v1/blogs/<blogId>/revisions", () => {
   test("Gets all the blog revisions for the chosen blog", async () => {
     const { factory, authenticatedClient, authenticatedUser } = await getTestFixtures();
 
-    const { blog, initialRevision } = await factory.blogs.insert({ author: authenticatedUser });
+    const blog = await factory.blogs.insert({ author: authenticatedUser });
     const blogRevisions = await fillArray(
       async () => {
         return await factory.blogRevisions.insert({ blog, editor: authenticatedUser });
@@ -25,10 +24,6 @@ describe("GET /api/v1/blogs/<blogId>/revisions", () => {
       10,
       { sequential: true },
     );
-    blogRevisions.push({
-      ...initialRevision,
-      content: az.with(z.record(z.string(), z.any())).parse(initialRevision.content),
-    });
 
     const factoryRevisionIds = blogRevisions.map((revision) => {
       return revision.id;
@@ -39,8 +34,7 @@ describe("GET /api/v1/blogs/<blogId>/revisions", () => {
       .expect(200);
 
     const revisions = parseBlogRevisionHistory(body.revisions);
-    // One more than the generated 10 because of the initially created revision from the blogs factory
-    expect(revisions.length).toBe(11);
+    expect(revisions.length).toBe(10);
 
     for (const revision of revisions) {
       if (factoryRevisionIds.includes(revision.id)) {
@@ -63,7 +57,7 @@ describe("GET /api/v1/blogs/<blogId>/revisions", () => {
   test("Can not get blog revisions for a blog the user does not own", async () => {
     const { factory, authenticatedClient } = await getTestFixtures();
 
-    const { blog } = await factory.blogs.insert();
+    const { blog } = await factory.blogs.insertWithRevision();
 
     const { body } = await authenticatedClient
       .get(`/api/v1/blogs/${blog.id}/revisions`)
@@ -95,7 +89,7 @@ describe("GET /api/v1/blogs/<blogId>/revisions", () => {
   test("Does not allow an unauthenticated user to view blog revisions", async () => {
     const { factory } = await getTestFixtures();
 
-    const { blog } = await factory.blogs.insert();
+    const { blog } = await factory.blogs.insertWithRevision();
 
     const { body } = await request(app).get(`/api/v1/blogs/${blog.id}/revisions`).expect(401);
 

--- a/apps/back-end/tests/server/blogs/getBlogs.test.ts
+++ b/apps/back-end/tests/server/blogs/getBlogs.test.ts
@@ -9,30 +9,27 @@ import {
 } from "@alextheman/utility";
 import { DataError } from "@alextheman/utility/v6";
 import { BlogState, parseBlogSummaries, parseBlogSummariesResponse } from "@lexicon/models";
-import { eq } from "drizzle-orm";
 import { describe, expect, test } from "vitest";
 
 import { randomUUID } from "node:crypto";
 
 import getTestFixtures from "tests/fixtures";
 
-import { blogRevisionsTable } from "src/database/schema";
 import selectUser from "src/models/users/selectUser";
 
 describe("GET /api/v1/blogs", () => {
   test("Returns all the blogs from all users", async () => {
     const { connection, factory, authenticatedClient } = await getTestFixtures();
 
-    const blogs = await fillArray(
+    const factoryBlogs = await fillArray(
       async () => {
-        const { blog } = await factory.blogs.insert();
-        return blog;
+        return await factory.blogs.insertWithRevision();
       },
       10,
       { sequential: true },
     );
 
-    const blogIds = blogs.map((blog) => {
+    const blogIds = factoryBlogs.map(({ blog }) => {
       return blog.id;
     });
 
@@ -43,9 +40,10 @@ describe("GET /api/v1/blogs", () => {
 
     for (const blogSummary of blogSummaries) {
       if (blogIds.includes(blogSummary.id)) {
-        const blog = blogs.find((blog) => {
-          return blogSummary.id === blog.id;
-        });
+        const { blog, revision } =
+          factoryBlogs.find(({ blog }) => {
+            return blogSummary.id === blog.id;
+          }) ?? {};
 
         assertNotUndefined(blog);
         expect(omitProperties(blogSummary, ["authorDisplayName", "authorUsername"])).toMatchObject(
@@ -57,15 +55,7 @@ describe("GET /api/v1/blogs", () => {
         expect(blogSummary.authorDisplayName).toBe(user.displayName);
         expect(blogSummary.authorUsername).toBe(user.username);
 
-        const [revision] = await connection
-          .select({
-            title: blogRevisionsTable.title,
-            content: blogRevisionsTable.content,
-          })
-          .from(blogRevisionsTable)
-          .where(eq(blogRevisionsTable.id, blog.currentRevisionId));
-
-        assertNotNull(revision);
+        assertNotUndefined(revision);
 
         expect(blogSummary.title).toBe(revision.title);
       } else {
@@ -85,7 +75,10 @@ describe("GET /api/v1/blogs", () => {
     const blogs = (
       await fillArray(
         async () => {
-          const { blog } = await factory.blogs.insert({ author, state: BlogState.PUBLISHED });
+          const { blog } = await factory.blogs.insertWithRevision({
+            author,
+            state: BlogState.PUBLISHED,
+          });
           return blog;
         },
         10,
@@ -132,7 +125,7 @@ describe("GET /api/v1/blogs", () => {
 
     await fillArray(
       async () => {
-        const { blog } = await factory.blogs.insert({ author });
+        const { blog } = await factory.blogs.insertWithRevision({ author });
         return blog;
       },
       5,

--- a/apps/back-end/tests/server/blogs/putBlogById.test.ts
+++ b/apps/back-end/tests/server/blogs/putBlogById.test.ts
@@ -1,6 +1,6 @@
 import type { EditBlogData } from "@lexicon/models";
 
-import { assertNotNull, isSameDate } from "@alextheman/utility";
+import { isSameDate } from "@alextheman/utility";
 import { CodeError, DataError } from "@alextheman/utility/v6";
 import { BlogState, parseBlogView } from "@lexicon/models";
 import { desc, eq } from "drizzle-orm";
@@ -18,9 +18,9 @@ describe("PUT /api/v1/blogs/<blogId>", () => {
   test("Updates the current blog and creates a new revision", async () => {
     const { connection, factory, authenticatedClient, authenticatedUser } = await getTestFixtures();
 
-    const { blog } = await factory.blogs.insert({ author: authenticatedUser });
-    const oldRevisionNumber = await findLatestBlogVersion(connection, blog.id);
-    assertNotNull(oldRevisionNumber);
+    const { blog, revision } = await factory.blogs.insertWithRevision({
+      author: authenticatedUser,
+    });
 
     const data: Partial<EditBlogData> = {
       state: blog.state,
@@ -41,7 +41,7 @@ describe("PUT /api/v1/blogs/<blogId>", () => {
     expect(blogView.content).toEqual(data.content);
 
     const newRevisionNumber = await findLatestBlogVersion(connection, blogView.id);
-    expect(newRevisionNumber).toBe(oldRevisionNumber + 1);
+    expect(newRevisionNumber).toBe(revision.version + 1);
   });
   test("Responds with a 404 error if the blog does not exist", async () => {
     const { authenticatedClient } = await getTestFixtures();
@@ -70,7 +70,7 @@ describe("PUT /api/v1/blogs/<blogId>", () => {
   test("If the blog state changed, insert a new state history record", async () => {
     const { connection, factory, authenticatedClient, authenticatedUser } = await getTestFixtures();
 
-    const { blog } = await factory.blogs.insert({
+    const { blog } = await factory.blogs.insertWithRevision({
       state: BlogState.DRAFT,
       author: authenticatedUser,
     });
@@ -99,8 +99,12 @@ describe("PUT /api/v1/blogs/<blogId>", () => {
   test("Only updates the blog with the given ID", async () => {
     const { connection, factory, authenticatedClient, authenticatedUser } = await getTestFixtures();
 
-    const { blog: firstBlog } = await factory.blogs.insert({ author: authenticatedUser });
-    const { blog: secondBlog } = await factory.blogs.insert({ author: authenticatedUser });
+    const { blog: firstBlog } = await factory.blogs.insertWithRevision({
+      author: authenticatedUser,
+    });
+    const { blog: secondBlog } = await factory.blogs.insertWithRevision({
+      author: authenticatedUser,
+    });
 
     const [{ secondBlogTitle, secondBlogContent }] = await connection
       .select({
@@ -134,7 +138,7 @@ describe("PUT /api/v1/blogs/<blogId>", () => {
   test("Does not allow editing of a blog that does not belong to the current user", async () => {
     const { factory, authenticatedClient } = await getTestFixtures();
 
-    const { blog } = await factory.blogs.insert();
+    const { blog } = await factory.blogs.insertWithRevision();
 
     const data: EditBlogData = {
       state: BlogState.PUBLISHED,


### PR DESCRIPTION
The standard blog insert method only generates the blog itself, whereas the previous behaviour is now stored under insertWithRevision, which generates the blog and its revision, and returns both. The blogRevision factory has also been changed so that it generates the revision contents more dynamically if no blog provided, as well as some other general updates. This allows blog revisions to be thought of as its own separate resource, which makes testing the blog revisions endpoints a lot easier.

# Tooling Change

This is a change to the tooling of `lexicon`. It changes the internal workings of the app and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
