### PR TITLE
Add user request binding to handleEndpointMiddleware

### DIFF
--- a/apps/back-end/src/utility/handlers/handleAuthenticatedEndpointMiddleware.ts
+++ b/apps/back-end/src/utility/handlers/handleAuthenticatedEndpointMiddleware.ts
@@ -2,12 +2,6 @@ import type { User } from "@lexicon/models";
 import type { NextFunction, Request, RequestHandler, Response } from "express";
 import type { ParamsDictionary } from "express-serve-static-core";
 
-import { assertNotNull } from "@alextheman/utility";
-import { parseUser } from "@lexicon/models";
-
-import { getConnection } from "src/database/connection";
-import selectUser from "src/models/users/selectUser";
-import selectUserSession from "src/models/userSessions/selectUserSession";
 import authRequiredError from "src/utility/errors/authRequiredError";
 import handleEndpointMiddleware from "src/utility/handlers/handleEndpointMiddleware";
 
@@ -36,22 +30,9 @@ function handleAuthenticatedEndpointMiddleware<
 ): RequestHandler<ParameterType, ResBody, ReqBody, ReqQuery, Locals> {
   return handleEndpointMiddleware<ParameterType, ResBody, ReqBody, ReqQuery, Locals>(
     async (request, response, next) => {
-      const connection = getConnection();
-      const sessionId = request.cookies.session;
-      if (!sessionId) {
-        throw authRequiredError(sessionId);
+      if (request.user === null) {
+        throw authRequiredError();
       }
-
-      const session = await selectUserSession(connection, sessionId);
-
-      if (session === null || session.expiresAt < new Date()) {
-        throw authRequiredError(sessionId);
-      }
-
-      const currentUser = await selectUser(connection, session);
-      assertNotNull(currentUser);
-      request.user = parseUser(currentUser);
-
       await middleware(
         request as AuthenticatedRequest<ParameterType, ResBody, ReqBody, ReqQuery, Locals>,
         response,

--- a/apps/back-end/src/utility/handlers/handleEndpointMiddleware.ts
+++ b/apps/back-end/src/utility/handlers/handleEndpointMiddleware.ts
@@ -1,6 +1,13 @@
 import type { RequestHandler } from "express";
 import type { ParamsDictionary } from "express-serve-static-core";
 
+import { az } from "@alextheman/utility";
+import z from "zod";
+
+import { getConnection } from "src/database/connection";
+import selectUser from "src/models/users/selectUser";
+import selectUserSession from "src/models/userSessions/selectUserSession";
+
 function handleEndpointMiddleware<
   ParameterType extends ParamsDictionary,
   ResBody = unknown,
@@ -10,7 +17,20 @@ function handleEndpointMiddleware<
 >(
   middleware: RequestHandler<ParameterType, ResBody, ReqBody, ReqQuery, Locals>,
 ): RequestHandler<ParameterType, ResBody, ReqBody, ReqQuery, Locals> {
-  return (request, response, next) => {
+  return async (request, response, next) => {
+    const connection = getConnection();
+    const sessionId = request.cookies.session;
+    const session = await selectUserSession(connection, sessionId);
+
+    const currentUser = session !== null ? await selectUser(connection, session) : null;
+    request.user =
+      currentUser !== null
+        ? {
+            ...currentUser,
+            dateOfBirth: az.with(z.coerce.date().nullable()).parse(currentUser.dateOfBirth),
+          }
+        : null;
+
     Promise.resolve(middleware(request, response, next)).catch(next);
   };
 }

--- a/apps/back-end/src/utility/types/express.d.ts
+++ b/apps/back-end/src/utility/types/express.d.ts
@@ -2,6 +2,6 @@ import type { User } from "@lexicon/models";
 
 declare module "express-serve-static-core" {
   interface Request {
-    user?: User;
+    user: User | null;
   }
 }


### PR DESCRIPTION
Previously if the user was signed in, the user wouldn't have been attached to the request even though they should really be. This changes that so that handleEndpointMiddleware now either attaches the user if they exist or gives a null user otherwise. handleAuthenticatedEndpointMiddleware goes one step further to ensure that the user is signed in, throwing an unauthorised error if not.

# Refactor

This is a change to the code layout of `lexicon`. It changes how the code is presented in terms of quality and structure without changing its overall user-facing behaviour or functionality.

Please see the commits tab of this pull request for the description of changes.
