### PR TITLE
Move the current user logic to its own handler separate from the endp…

### DIFF
--- a/apps/back-end/src/server/app.ts
+++ b/apps/back-end/src/server/app.ts
@@ -5,15 +5,15 @@ import "src/instrument";
 import { resolveErrors } from "src/server/errors";
 import createEndpoints from "src/server/routes";
 import loadAllowedOrigins from "src/utility/env/loadAllowedOrigins";
+import loadCurrentUser from "src/utility/handlers/loadCurrentUser";
 import setupCors from "src/utility/initialisers/setupCors";
 
 const app = express();
 
-app.use(express.json());
-
 app.use(setupCors(loadAllowedOrigins()));
 app.use(express.json());
 app.use(cookieParser());
+app.use(loadCurrentUser);
 
 createEndpoints(app);
 resolveErrors(app);

--- a/apps/back-end/src/utility/handlers/handleEndpointMiddleware.ts
+++ b/apps/back-end/src/utility/handlers/handleEndpointMiddleware.ts
@@ -1,13 +1,6 @@
 import type { RequestHandler } from "express";
 import type { ParamsDictionary } from "express-serve-static-core";
 
-import { az } from "@alextheman/utility";
-import z from "zod";
-
-import { getConnection } from "src/database/connection";
-import selectUser from "src/models/users/selectUser";
-import selectUserSession from "src/models/userSessions/selectUserSession";
-
 function handleEndpointMiddleware<
   ParameterType extends ParamsDictionary,
   ResBody = unknown,
@@ -18,19 +11,6 @@ function handleEndpointMiddleware<
   middleware: RequestHandler<ParameterType, ResBody, ReqBody, ReqQuery, Locals>,
 ): RequestHandler<ParameterType, ResBody, ReqBody, ReqQuery, Locals> {
   return async (request, response, next) => {
-    const connection = getConnection();
-    const sessionId = request.cookies.session;
-    const session = await selectUserSession(connection, sessionId);
-
-    const currentUser = session !== null ? await selectUser(connection, session) : null;
-    request.user =
-      currentUser !== null
-        ? {
-            ...currentUser,
-            dateOfBirth: az.with(z.coerce.date().nullable()).parse(currentUser.dateOfBirth),
-          }
-        : null;
-
     Promise.resolve(middleware(request, response, next)).catch(next);
   };
 }

--- a/apps/back-end/src/utility/handlers/loadCurrentUser.ts
+++ b/apps/back-end/src/utility/handlers/loadCurrentUser.ts
@@ -1,0 +1,24 @@
+import { az } from "@alextheman/utility";
+import z from "zod";
+
+import { getConnection } from "src/database/connection";
+import selectUser from "src/models/users/selectUser";
+import selectUserSession from "src/models/userSessions/selectUserSession";
+import handleFallthroughMiddleware from "src/utility/handlers/handleFallthroughMiddleware";
+
+const loadCurrentUser = handleFallthroughMiddleware(async (request) => {
+  const connection = getConnection();
+  const sessionId = z.uuid().optional().catch(undefined).parse(request.cookies?.session);
+  const session = sessionId !== undefined ? await selectUserSession(connection, sessionId) : null;
+
+  const currentUser = session !== null ? await selectUser(connection, session) : null;
+  request.user =
+    currentUser !== null
+      ? {
+          ...currentUser,
+          dateOfBirth: az.with(z.coerce.date().nullable()).parse(currentUser.dateOfBirth),
+        }
+      : null;
+});
+
+export default loadCurrentUser;


### PR DESCRIPTION
…oint handlers

That way each individual endpoint handler doesn't need to also worry about user binding logic - it can now be done once at the app level and the endpoint handlers can be more pure as a result.

# Tooling Change

This is a change to the tooling of `lexicon`. It changes the internal workings of the app and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
