### PR TITLE
Refactor the codebase to use the new database filter helpers

### DIFF
--- a/apps/back-end/src/models/auth/insertUserAuthProvider.ts
+++ b/apps/back-end/src/models/auth/insertUserAuthProvider.ts
@@ -4,12 +4,15 @@ import type { AuthProviderInsert, AuthProviderSchema } from "src/database/schema
 import { assertNotNullable } from "@alextheman/utility";
 
 import { authProvidersTable } from "src/database/schema";
+import fetchSole from "src/utility/databaseFilters/fetchSole";
 
 async function insertUserAuthProvider(
   connection: Connection,
   data: AuthProviderInsert,
 ): Promise<AuthProviderSchema> {
-  const [newProvider] = await connection.insert(authProvidersTable).values(data).returning();
+  const newProvider = await fetchSole(
+    connection.insert(authProvidersTable).values(data).returning(),
+  );
   assertNotNullable(newProvider);
   return newProvider;
 }

--- a/apps/back-end/src/models/auth/selectUserAuthProvider.ts
+++ b/apps/back-end/src/models/auth/selectUserAuthProvider.ts
@@ -6,6 +6,7 @@ import type { AuthProviderSchema } from "src/database/schema";
 import { and, eq } from "drizzle-orm";
 
 import { authProvidersTable } from "src/database/schema";
+import fetchSole from "src/utility/databaseFilters/fetchSole";
 
 export interface SelectAuthProviderQuery {
   provider?: AuthProvider;
@@ -16,17 +17,19 @@ async function selectUserAuthProvider(
   connection: Connection,
   { provider, providerUserId }: SelectAuthProviderQuery,
 ): Promise<AuthProviderSchema | null> {
-  const [authProvider] = await connection
-    .select()
-    .from(authProvidersTable)
-    .where(
-      and(
-        provider !== undefined ? eq(authProvidersTable.provider, provider) : undefined,
-        providerUserId !== undefined
-          ? eq(authProvidersTable.providerUserId, providerUserId)
-          : undefined,
+  const authProvider = await fetchSole(
+    connection
+      .select()
+      .from(authProvidersTable)
+      .where(
+        and(
+          provider !== undefined ? eq(authProvidersTable.provider, provider) : undefined,
+          providerUserId !== undefined
+            ? eq(authProvidersTable.providerUserId, providerUserId)
+            : undefined,
+        ),
       ),
-    );
+  );
 
   return authProvider ?? null;
 }

--- a/apps/back-end/src/models/blogs/insertBlog.ts
+++ b/apps/back-end/src/models/blogs/insertBlog.ts
@@ -4,9 +4,10 @@ import type { Blog, BlogInsert } from "src/database/schema";
 import { assertNotNullable } from "@alextheman/utility";
 
 import { blogsTable } from "src/database/schema";
+import fetchSole from "src/utility/databaseFilters/fetchSole";
 
 async function insertBlog(connection: Connection, data: BlogInsert): Promise<Blog> {
-  const [blog] = await connection.insert(blogsTable).values(data).returning();
+  const blog = await fetchSole(connection.insert(blogsTable).values(data).returning());
   assertNotNullable(blog);
   return blog;
 }

--- a/apps/back-end/src/models/blogs/insertBlogRevision.ts
+++ b/apps/back-end/src/models/blogs/insertBlogRevision.ts
@@ -1,16 +1,20 @@
 import type { Connection } from "src/database/connection";
 import type { BlogRevision, BlogRevisionInsert } from "src/database/schema";
 
-import { az } from "@alextheman/utility";
+import { assertNotNull, az } from "@alextheman/utility";
 import z from "zod";
 
 import { blogRevisionsTable } from "src/database/schema";
+import fetchSole from "src/utility/databaseFilters/fetchSole";
 
 async function insertBlogRevision(
   connection: Connection,
   data: BlogRevisionInsert,
 ): Promise<BlogRevision> {
-  const [blogRevision] = await connection.insert(blogRevisionsTable).values(data).returning();
+  const blogRevision = await fetchSole(
+    connection.insert(blogRevisionsTable).values(data).returning(),
+  );
+  assertNotNull(blogRevision);
   return {
     ...blogRevision,
     content: az.with(z.record(z.string(), z.any())).parse(blogRevision.content),

--- a/apps/back-end/src/models/blogs/insertBlogStateHistory.ts
+++ b/apps/back-end/src/models/blogs/insertBlogStateHistory.ts
@@ -1,16 +1,19 @@
 import type { Connection } from "src/database/connection";
 import type { BlogStateHistoryInsert, BlogStateHistoryRow } from "src/database/schema";
 
+import { assertNotNull } from "@alextheman/utility";
+
 import { blogStateHistoryTable } from "src/database/schema";
+import fetchSole from "src/utility/databaseFilters/fetchSole";
 
 async function insertBlogStateHistory(
   connection: Connection,
   data: BlogStateHistoryInsert,
 ): Promise<BlogStateHistoryRow> {
-  const [blogStateHistory] = await connection
-    .insert(blogStateHistoryTable)
-    .values(data)
-    .returning();
+  const blogStateHistory = await fetchSole(
+    connection.insert(blogStateHistoryTable).values(data).returning(),
+  );
+  assertNotNull(blogStateHistory);
   return blogStateHistory;
 }
 

--- a/apps/back-end/src/models/blogs/selectBlog.ts
+++ b/apps/back-end/src/models/blogs/selectBlog.ts
@@ -4,10 +4,13 @@ import type { Blog } from "src/database/schema";
 import { eq } from "drizzle-orm";
 
 import { blogsTable } from "src/database/schema";
+import fetchSole from "src/utility/databaseFilters/fetchSole";
 
 async function selectBlog(connection: Connection, blogId: string): Promise<Blog | null> {
-  const [blog] = await connection.select().from(blogsTable).where(eq(blogsTable.id, blogId));
-  return blog ?? null;
+  const blog = await fetchSole(
+    connection.select().from(blogsTable).where(eq(blogsTable.id, blogId)),
+  );
+  return blog;
 }
 
 export default selectBlog;

--- a/apps/back-end/src/models/blogs/selectBlogRevisions.ts
+++ b/apps/back-end/src/models/blogs/selectBlogRevisions.ts
@@ -6,6 +6,7 @@ import { desc, eq } from "drizzle-orm";
 import z from "zod";
 
 import { blogRevisionsTable } from "src/database/schema";
+import fetchAll from "src/utility/databaseFilters/fetchAll";
 
 interface SelectBlogRevisionFilters {
   blogId: string;
@@ -15,11 +16,13 @@ async function selectBlogRevisions(
   connection: Connection,
   { blogId }: SelectBlogRevisionFilters,
 ): Promise<Array<BlogRevision>> {
-  const revisions = await connection
-    .select()
-    .from(blogRevisionsTable)
-    .where(eq(blogRevisionsTable.blogId, blogId))
-    .orderBy(desc(blogRevisionsTable.version));
+  const revisions = await fetchAll(
+    connection
+      .select()
+      .from(blogRevisionsTable)
+      .where(eq(blogRevisionsTable.blogId, blogId))
+      .orderBy(desc(blogRevisionsTable.version)),
+  );
 
   return revisions.map((revision) => {
     return { ...revision, content: az.with(z.record(z.string(), z.any())).parse(revision.content) };

--- a/apps/back-end/src/models/blogs/updateBlog.ts
+++ b/apps/back-end/src/models/blogs/updateBlog.ts
@@ -4,14 +4,13 @@ import type { BlogUpdate } from "src/database/schema";
 import { eq } from "drizzle-orm";
 
 import { blogsTable } from "src/database/schema";
+import fetchSole from "src/utility/databaseFilters/fetchSole";
 
 async function updateBlog(connection: Connection, blogId: string, data: BlogUpdate) {
-  const [blog] = await connection
-    .update(blogsTable)
-    .set(data)
-    .where(eq(blogsTable.id, blogId))
-    .returning();
-  return blog ?? null;
+  const blog = await fetchSole(
+    connection.update(blogsTable).set(data).where(eq(blogsTable.id, blogId)).returning(),
+  );
+  return blog;
 }
 
 export default updateBlog;

--- a/apps/back-end/src/models/userSessions/insertUserSession.ts
+++ b/apps/back-end/src/models/userSessions/insertUserSession.ts
@@ -4,12 +4,13 @@ import type { UserSession, UserSessionInsert } from "src/database/schema";
 import { assertNotNullable } from "@alextheman/utility";
 
 import { userSessionsTable } from "src/database/schema";
+import fetchSole from "src/utility/databaseFilters/fetchSole";
 
 async function insertUserSession(
   connection: Connection,
   data: UserSessionInsert,
 ): Promise<UserSession> {
-  const [session] = await connection.insert(userSessionsTable).values(data).returning();
+  const session = await fetchSole(connection.insert(userSessionsTable).values(data).returning());
   assertNotNullable(session);
   return session;
 }

--- a/apps/back-end/src/models/userSessions/selectUserSession.ts
+++ b/apps/back-end/src/models/userSessions/selectUserSession.ts
@@ -4,15 +4,15 @@ import type { UserSession } from "src/database/schema";
 import { eq } from "drizzle-orm";
 
 import { userSessionsTable } from "src/database/schema";
+import fetchSole from "src/utility/databaseFilters/fetchSole";
 
 async function selectUserSession(
   connection: Connection,
   sessionId: string,
 ): Promise<UserSession | null> {
-  const [session] = await connection
-    .select()
-    .from(userSessionsTable)
-    .where(eq(userSessionsTable.id, sessionId));
+  const session = await fetchSole(
+    connection.select().from(userSessionsTable).where(eq(userSessionsTable.id, sessionId)),
+  );
   return session ?? null;
 }
 

--- a/apps/back-end/src/models/userSessions/updateUserSession.ts
+++ b/apps/back-end/src/models/userSessions/updateUserSession.ts
@@ -4,17 +4,20 @@ import type { UserSession, UserSessionUpdate } from "src/database/schema";
 import { eq } from "drizzle-orm";
 
 import { userSessionsTable } from "src/database/schema";
+import fetchSole from "src/utility/databaseFilters/fetchSole";
 
 async function updateUserSession(
   connection: Connection,
   sessionId: string,
   data: UserSessionUpdate,
 ): Promise<UserSession | null> {
-  const [userSession] = await connection
-    .update(userSessionsTable)
-    .set(data)
-    .where(eq(userSessionsTable.id, sessionId))
-    .returning();
+  const userSession = await fetchSole(
+    connection
+      .update(userSessionsTable)
+      .set(data)
+      .where(eq(userSessionsTable.id, sessionId))
+      .returning(),
+  );
 
   return userSession ?? null;
 }

--- a/apps/back-end/src/models/users/insertUser.ts
+++ b/apps/back-end/src/models/users/insertUser.ts
@@ -4,9 +4,10 @@ import type { User, UserInsert } from "src/database/schema";
 import { assertNotNullable } from "@alextheman/utility";
 
 import { usersTable } from "src/database/schema";
+import fetchSole from "src/utility/databaseFilters/fetchSole";
 
 export async function insertUser(connection: Connection, data: UserInsert): Promise<User> {
-  const [user] = await connection.insert(usersTable).values(data).returning();
+  const user = await fetchSole(connection.insert(usersTable).values(data).returning());
   assertNotNullable(user);
   return user;
 }

--- a/apps/back-end/src/models/users/selectUser.ts
+++ b/apps/back-end/src/models/users/selectUser.ts
@@ -1,9 +1,10 @@
 import type { Connection } from "src/database/connection";
 import type { User } from "src/database/schema";
 
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
 import { usersTable } from "src/database/schema";
+import fetchSole from "src/utility/databaseFilters/fetchSole";
 
 interface SelectUserFilterUserId {
   userId: string;
@@ -18,13 +19,18 @@ interface SelectUserFilterEmail {
 type SelectUserFilter = SelectUserFilterUserId | SelectUserFilterEmail;
 
 async function selectUser(connection: Connection, filters: SelectUserFilter): Promise<User | null> {
-  const query = connection.select().from(usersTable);
+  const user = fetchSole(
+    connection
+      .select()
+      .from(usersTable)
+      .where(
+        and(
+          filters.userId !== undefined ? eq(usersTable.id, filters.userId) : undefined,
+          filters.email !== undefined ? eq(usersTable.email, filters.email) : undefined,
+        ),
+      ),
+  );
 
-  const [user] = filters.userId
-    ? await query.where(eq(usersTable.id, filters.userId))
-    : filters.email
-      ? await query.where(eq(usersTable.email, filters.email))
-      : [];
   return user ?? null;
 }
 

--- a/apps/back-end/src/models/users/updateUser.ts
+++ b/apps/back-end/src/models/users/updateUser.ts
@@ -4,17 +4,16 @@ import type { User, UserUpdate } from "src/database/schema";
 import { eq } from "drizzle-orm";
 
 import { usersTable } from "src/database/schema";
+import fetchSole from "src/utility/databaseFilters/fetchSole";
 
 async function updateUser(
   connection: Connection,
   userId: string,
   data: UserUpdate,
 ): Promise<User | null> {
-  const [user] = await connection
-    .update(usersTable)
-    .set(data)
-    .where(eq(usersTable.id, userId))
-    .returning();
+  const user = await fetchSole(
+    connection.update(usersTable).set(data).where(eq(usersTable.id, userId)).returning(),
+  );
 
   return user ?? null;
 }

--- a/apps/back-end/src/services/blogs/findLatestBlogRevision.ts
+++ b/apps/back-end/src/services/blogs/findLatestBlogRevision.ts
@@ -3,17 +3,21 @@ import type { Connection } from "src/database/connection";
 import { desc, eq } from "drizzle-orm";
 
 import { blogRevisionsTable } from "src/database/schema";
+import fetchFirst from "src/utility/databaseFilters/fetchFirst";
 
 async function findLatestBlogVersion(
   connection: Connection,
   blogId: string,
 ): Promise<number | null> {
-  const [revision] = await connection
-    .select({ version: blogRevisionsTable.version })
-    .from(blogRevisionsTable)
-    .where(eq(blogRevisionsTable.blogId, blogId))
-    .orderBy(desc(blogRevisionsTable.version));
-  return revision?.version === undefined || revision?.version === null ? null : revision.version;
+  const revision = await fetchFirst(
+    connection
+      .select({ version: blogRevisionsTable.version })
+      .from(blogRevisionsTable)
+      .where(eq(blogRevisionsTable.blogId, blogId))
+      .orderBy(desc(blogRevisionsTable.version)),
+  );
+
+  return revision === null ? null : revision.version;
 }
 
 export default findLatestBlogVersion;

--- a/apps/back-end/src/services/blogs/loadBlogSummaries.ts
+++ b/apps/back-end/src/services/blogs/loadBlogSummaries.ts
@@ -5,6 +5,7 @@ import type { Connection } from "src/database/connection";
 import { eq, inArray, sql } from "drizzle-orm";
 
 import { blogRevisionsTable, blogsTable, usersTable } from "src/database/schema";
+import fetchAll from "src/utility/databaseFilters/fetchAll";
 
 async function loadBlogSummaries(
   connection: Connection,
@@ -34,7 +35,7 @@ async function loadBlogSummaries(
         .orderBy(sql`ARRAY_POSITION(${sql.param(blogIds)}::UUID[], ${blogsTable.id})`)
     : baseQuery;
 
-  const blogs = await query;
+  const blogs = await fetchAll(query);
   return blogs.map((blog) => {
     return {
       ...blog,

--- a/apps/back-end/src/services/blogs/loadBlogView.ts
+++ b/apps/back-end/src/services/blogs/loadBlogView.ts
@@ -7,6 +7,7 @@ import { and, eq } from "drizzle-orm";
 import z from "zod";
 
 import { blogRevisionsTable, blogsTable, usersTable } from "src/database/schema";
+import fetchSole from "src/utility/databaseFilters/fetchSole";
 
 interface BlogViewFilter {
   blogId: string;
@@ -17,40 +18,42 @@ async function loadBlogView(
   connection: Connection,
   { blogId, revisionNumber }: BlogViewFilter,
 ): Promise<BlogView | null> {
-  const [blog] = await connection
-    .select({
-      id: blogsTable.id,
-      revisionNumber: blogRevisionsTable.version,
-      authorId: blogsTable.authorId,
-      authorUsername: usersTable.username,
-      authorDisplayName: usersTable.displayName,
-      updatedAt: blogsTable.updatedAt,
-      state: blogsTable.state,
-      publishedAt: blogsTable.publishedAt,
-      title: blogRevisionsTable.title,
-      content: blogRevisionsTable.content,
-    })
-    .from(blogsTable)
-    .innerJoin(blogRevisionsTable, eq(blogRevisionsTable.blogId, blogsTable.id))
-    .innerJoin(usersTable, eq(blogsTable.authorId, usersTable.id))
-    .where(
-      and(
-        eq(blogsTable.id, blogId),
-        revisionNumber !== undefined
-          ? eq(blogRevisionsTable.version, revisionNumber)
-          : eq(blogRevisionsTable.id, blogsTable.currentRevisionId),
+  const blog = await fetchSole(
+    connection
+      .select({
+        id: blogsTable.id,
+        revisionNumber: blogRevisionsTable.version,
+        authorId: blogsTable.authorId,
+        authorUsername: usersTable.username,
+        authorDisplayName: usersTable.displayName,
+        updatedAt: blogsTable.updatedAt,
+        state: blogsTable.state,
+        publishedAt: blogsTable.publishedAt,
+        title: blogRevisionsTable.title,
+        content: blogRevisionsTable.content,
+      })
+      .from(blogsTable)
+      .innerJoin(blogRevisionsTable, eq(blogRevisionsTable.blogId, blogsTable.id))
+      .innerJoin(usersTable, eq(blogsTable.authorId, usersTable.id))
+      .where(
+        and(
+          eq(blogsTable.id, blogId),
+          revisionNumber !== undefined
+            ? eq(blogRevisionsTable.version, revisionNumber)
+            : eq(blogRevisionsTable.id, blogsTable.currentRevisionId),
+        ),
       ),
-    );
+  );
 
-  if (blog) {
-    return {
-      ...blog,
-      authorDisplayName: blog.authorDisplayName ?? blog.authorUsername,
-      content: az.with(z.record(z.string(), z.any())).parse(blog.content),
-    };
+  if (blog === null) {
+    return null;
   }
 
-  return null;
+  return {
+    ...blog,
+    authorDisplayName: blog.authorDisplayName ?? blog.authorUsername,
+    content: az.with(z.record(z.string(), z.any())).parse(blog.content),
+  };
 }
 
 export default loadBlogView;

--- a/apps/back-end/src/utility/databaseFilters/fetchAll.ts
+++ b/apps/back-end/src/utility/databaseFilters/fetchAll.ts
@@ -1,0 +1,5 @@
+async function fetchAll<ItemType>(query: Promise<Array<ItemType>>): Promise<Array<ItemType>> {
+  return await query;
+}
+
+export default fetchAll;

--- a/apps/back-end/src/utility/databaseFilters/fetchFirst.ts
+++ b/apps/back-end/src/utility/databaseFilters/fetchFirst.ts
@@ -1,0 +1,6 @@
+async function fetchFirst<ItemType>(query: Promise<Array<ItemType>>): Promise<ItemType | null> {
+  const [first] = await query;
+  return first ?? null;
+}
+
+export default fetchFirst;

--- a/apps/back-end/src/utility/databaseFilters/fetchSole.ts
+++ b/apps/back-end/src/utility/databaseFilters/fetchSole.ts
@@ -1,0 +1,15 @@
+import { DataError } from "@alextheman/utility/v6";
+
+async function fetchSole<ItemType>(query: Promise<Array<ItemType>>): Promise<ItemType | null> {
+  const results = await query;
+  if (results.length > 1) {
+    throw new DataError(
+      { length: results.length },
+      "MULTIPLE_ROWS_ERROR",
+      "Expected only one or zero rows to be returned.",
+    );
+  }
+  return results[0] ?? null;
+}
+
+export default fetchSole;


### PR DESCRIPTION
Previously all our model/service functions did the query in-line and destructured to get the first one. However, now I've not only added fetchFirst to deal with the initial behaviour, but I've also added fetchSole, which can be used in cases where we only want to get the first item from a query and error if we get more than one. This should lead to safer queries and less unexpected results where a query may unintentionally return multiple rows but we don't catch it because we just always destructure the first.

# Refactor

This is a change to the code layout of `lexicon`. It changes how the code is presented in terms of quality and structure without changing its overall user-facing behaviour or functionality.

Please see the commits tab of this pull request for the description of changes.
