### PR TITLE
Make the test client its own standalone fixture

### DIFF
--- a/apps/back-end/tests/fixtures/testClient.ts
+++ b/apps/back-end/tests/fixtures/testClient.ts
@@ -1,0 +1,7 @@
+import request from "supertest";
+
+import app from "src/server/app";
+
+const testClient = request(app);
+
+export default testClient;

--- a/apps/back-end/tests/server/auth/getAuthGoogleCallback.test.ts
+++ b/apps/back-end/tests/server/auth/getAuthGoogleCallback.test.ts
@@ -3,16 +3,15 @@ import { parseUser } from "@lexicon/models";
 import { eq } from "drizzle-orm";
 // eslint-disable-next-line @alextheman/no-namespace-imports
 import * as OpenIDClient from "openid-client";
-import request from "supertest";
 import { describe, expect, test, vi } from "vitest";
 
 import getTestFixtures from "tests/fixtures";
+import testClient from "tests/fixtures/testClient";
 import COOKIES from "tests/server/auth/helpers/COOKIES";
 import getSetCookies from "tests/server/auth/helpers/getSetCookies";
 
 import { usersTable } from "src/database/schema";
 import selectUser from "src/models/users/selectUser";
-import app from "src/server/app";
 
 vi.mock("openid-client", async () => {
   return {
@@ -46,7 +45,7 @@ describe("GET /api/v1/auth/google/callback", () => {
       token_type: "Bearer",
     } as any);
 
-    const { body, headers } = await request(app)
+    const { body, headers } = await testClient
       .get("/api/v1/auth/google/callback")
       .query({ code: "test-code", state: "valid-state" })
       .set("Cookie", COOKIES)
@@ -86,7 +85,7 @@ describe("GET /api/v1/auth/google/callback", () => {
       token_type: "Bearer",
     } as any);
 
-    const { body, headers } = await request(app)
+    const { body, headers } = await testClient
       .get("/api/v1/auth/google/callback")
       .query({ code: "test-code", state: "valid-state" })
       .set("Cookie", COOKIES)
@@ -126,7 +125,7 @@ describe("GET /api/v1/auth/google/callback", () => {
       token_type: "Bearer",
     } as any);
 
-    const { body, headers } = await request(app)
+    const { body, headers } = await testClient
       .get("/api/v1/auth/google/callback")
       .query({ code: "test-code", state: "valid-state" })
       .set("Cookie", COOKIES)

--- a/apps/back-end/tests/server/blogs/getBlogById.test.ts
+++ b/apps/back-end/tests/server/blogs/getBlogById.test.ts
@@ -2,15 +2,14 @@ import { assertNotNull, omitProperties } from "@alextheman/utility";
 import { DataError } from "@alextheman/utility/v6";
 import { parseBlogView } from "@lexicon/models";
 import BlogFactory from "factory/blogs";
-import request from "supertest";
 import { describe, expect, test } from "vitest";
 
 import { randomUUID } from "node:crypto";
 
 import getTestFixtures from "tests/fixtures";
+import testClient from "tests/fixtures/testClient";
 
 import selectUser from "src/models/users/selectUser";
-import app from "src/server/app";
 
 describe("GET /api/v1/blogs/<blogId>", () => {
   test("Returns the blog with the given blog ID", async () => {
@@ -99,7 +98,7 @@ describe("GET /api/v1/blogs/<blogId>", () => {
       content: BlogFactory.generateEditorContent("New content"),
     });
 
-    const { body } = await request(app)
+    const { body } = await testClient
       .get(`/api/v1/blogs/${blog.id}`)
       .query({ revisionNumber: initialRevision.version })
       .expect(404);

--- a/apps/back-end/tests/server/blogs/getBlogRevisionsByBlogId.test.ts
+++ b/apps/back-end/tests/server/blogs/getBlogRevisionsByBlogId.test.ts
@@ -3,14 +3,12 @@ import type { ResourceNotFoundErrorPayload } from "src/utility/errors/resourceNo
 import { assertNotUndefined, fillArray, paralleliseArrays, sortBy } from "@alextheman/utility";
 import { CodeError, DataError } from "@alextheman/utility/v6";
 import { parseBlogRevisionHistory } from "@lexicon/models";
-import request from "supertest";
 import { describe, expect, test } from "vitest";
 
 import { randomUUID } from "node:crypto";
 
 import getTestFixtures from "tests/fixtures";
-
-import app from "src/server/app";
+import testClient from "tests/fixtures/testClient";
 
 describe("GET /api/v1/blogs/<blogId>/revisions", () => {
   test("Gets all the blog revisions for the chosen blog", async () => {
@@ -84,7 +82,7 @@ describe("GET /api/v1/blogs/<blogId>/revisions", () => {
 
     const { blog } = await factory.blogs.insertWithRevision();
 
-    const { body } = await request(app).get(`/api/v1/blogs/${blog.id}/revisions`).expect(401);
+    const { body } = await testClient.get(`/api/v1/blogs/${blog.id}/revisions`).expect(401);
 
     const error = CodeError.expectError(() => {
       throw body.error;

--- a/apps/back-end/tests/server/blogs/postBlog.test.ts
+++ b/apps/back-end/tests/server/blogs/postBlog.test.ts
@@ -4,14 +4,12 @@ import { assertNotNull, isSameDate } from "@alextheman/utility";
 import { DataError } from "@alextheman/utility/v6";
 import { BlogState, parseBlogView } from "@lexicon/models";
 import BlogFactory from "factory/blogs";
-import request from "supertest";
 import { describe, expect, test } from "vitest";
 
 import { randomUUID } from "node:crypto";
 
 import getTestFixtures from "tests/fixtures";
-
-import app from "src/server/app";
+import testClient from "tests/fixtures/testClient";
 
 describe("POST /api/v1/blogs", () => {
   test("Inserts a blog into the database", async () => {
@@ -42,7 +40,7 @@ describe("POST /api/v1/blogs", () => {
       content: BlogFactory.generateEditorContent("Test blog"),
     };
 
-    const { body } = await request(app).post("/api/v1/blogs").send(data).expect(401);
+    const { body } = await testClient.post("/api/v1/blogs").send(data).expect(401);
 
     const error = DataError.expectError(() => {
       throw body.error;

--- a/apps/back-end/tests/server/currentUser/getCurrentUser.test.ts
+++ b/apps/back-end/tests/server/currentUser/getCurrentUser.test.ts
@@ -1,13 +1,11 @@
 import { addDaysToDate } from "@alextheman/utility";
 import { parseUser } from "@lexicon/models";
-import request from "supertest";
 import { describe, expect, test } from "vitest";
 
 import { randomUUID } from "node:crypto";
 
 import getTestFixtures from "tests/fixtures";
-
-import app from "src/server/app";
+import testClient from "tests/fixtures/testClient";
 
 describe("GET /api/v1/current-user", () => {
   test("Get the currently signed in user", async () => {
@@ -19,7 +17,7 @@ describe("GET /api/v1/current-user", () => {
     expect(signedInUser).toMatchObject(authenticatedUser);
   });
   test("If there is currently no session, return a null user", async () => {
-    const { body } = await request(app).get("/api/v1/current-user").expect(200);
+    const { body } = await testClient.get("/api/v1/current-user").expect(200);
     expect(body.user).toBeNull();
   });
   test("If session is expired, return null user", async () => {
@@ -31,14 +29,14 @@ describe("GET /api/v1/current-user", () => {
       expiresAt: addDaysToDate(new Date(), -1),
     });
 
-    const { body } = await request(app)
+    const { body } = await testClient
       .get("/api/v1/current-user")
       .set("Cookie", [`session=${session.id}`])
       .expect(200);
     expect(body.user).toBeNull();
   });
   test("If session does not exist, return null user", async () => {
-    const { body } = await request(app)
+    const { body } = await testClient
       .get("/api/v1/current-user")
       .set("Cookie", [`session=${randomUUID()}`])
       .expect(200);

--- a/apps/back-end/tests/server/errors.test.ts
+++ b/apps/back-end/tests/server/errors.test.ts
@@ -1,14 +1,13 @@
 import type { EndpointNotFoundErrorPayload } from "src/utility/errors/endpointNotFoundError";
 
 import { CodeError, DataError } from "@alextheman/utility/v6";
-import request from "supertest";
 import { describe, expect, test } from "vitest";
 
-import app from "src/server/app";
+import testClient from "tests/fixtures/testClient";
 
 describe("/api/v1/control/be-error", () => {
   test("Should throw an internal server error", async () => {
-    const { body } = await request(app).get("/api/v1/control/be-error").expect(500);
+    const { body } = await testClient.get("/api/v1/control/be-error").expect(500);
 
     const error = CodeError.expectError(() => {
       throw body.error;
@@ -20,7 +19,7 @@ describe("/api/v1/control/be-error", () => {
 
 describe("*", () => {
   test("Throws a 404 error if the endpoint is not found", async () => {
-    const { body } = await request(app).get("/api/v1/invalid").expect(404);
+    const { body } = await testClient.get("/api/v1/invalid").expect(404);
 
     const error = DataError.expectError<EndpointNotFoundErrorPayload>(() => {
       throw body.error;

--- a/apps/back-end/tests/server/users/getUserById.test.ts
+++ b/apps/back-end/tests/server/users/getUserById.test.ts
@@ -1,20 +1,18 @@
 import { DataError } from "@alextheman/utility/v6";
 import { parseUser } from "@lexicon/models";
-import request from "supertest";
 import { describe, expect, test } from "vitest";
 
 import { randomUUID } from "node:crypto";
 
 import getTestFixtures from "tests/fixtures";
-
-import app from "src/server/app";
+import testClient from "tests/fixtures/testClient";
 
 describe("GET /api/v1/users/<userId>", () => {
   test("Should get the user with the given ID", async () => {
     const { factory } = await getTestFixtures();
     const user = await factory.users.insert();
 
-    const { body } = await request(app).get(`/api/v1/users/${user.id}`).expect(200);
+    const { body } = await testClient.get(`/api/v1/users/${user.id}`).expect(200);
     const userPayload = parseUser(body.user);
 
     expect(userPayload).toMatchObject(user);
@@ -22,7 +20,7 @@ describe("GET /api/v1/users/<userId>", () => {
   test("Should fail with 404 if the ID is not found", async () => {
     const missingId = randomUUID();
 
-    const { body } = await request(app).get(`/api/v1/users/${missingId}`).expect(404);
+    const { body } = await testClient.get(`/api/v1/users/${missingId}`).expect(404);
 
     const error = DataError.expectError(() => {
       throw body.error;
@@ -33,7 +31,7 @@ describe("GET /api/v1/users/<userId>", () => {
     expect(error.data.resourceId).toBe(missingId);
   });
   test("Should fail with 400 if not a valid UUID", async () => {
-    const { body } = await request(app).get(`/api/v1/users/hello`).expect(400);
+    const { body } = await testClient.get(`/api/v1/users/hello`).expect(400);
     const error = DataError.expectError(() => {
       throw body.error;
     });

--- a/apps/back-end/tests/trivial.test.ts
+++ b/apps/back-end/tests/trivial.test.ts
@@ -1,11 +1,10 @@
-import request from "supertest";
 import { describe, expect, test } from "vitest";
 
-import app from "src/server/app";
+import testClient from "tests/fixtures/testClient";
 
 describe("Trivial test", () => {
   test("Trivial endpoint query", async () => {
-    const { body } = await request(app).get("/api/v1").expect(200);
+    const { body } = await testClient.get("/api/v1").expect(200);
     expect(body.hello).toBe("world");
   });
 });

--- a/apps/back-end/tests/validators/requireAuth.test.ts
+++ b/apps/back-end/tests/validators/requireAuth.test.ts
@@ -1,14 +1,12 @@
 import { parseUser } from "@lexicon/models";
-import request from "supertest";
 import { describe, expect, test } from "vitest";
 
 import getTestFixtures from "tests/fixtures";
-
-import app from "src/server/app";
+import testClient from "tests/fixtures/testClient";
 
 describe("requireAuth", () => {
   test("Protects an endpoint if no auth present", async () => {
-    const { body } = await request(app).get("/api/v1/protected").expect(401);
+    const { body } = await testClient.get("/api/v1/protected").expect(401);
     expect(body.error.code).toBe("AUTH_REQUIRED");
   });
   test("Allows the endpoint logic to run if auth present", async () => {
@@ -17,7 +15,7 @@ describe("requireAuth", () => {
     const user = await factory.users.insert();
     const session = await factory.userSessions.insert({ user });
 
-    const { body } = await request(app)
+    const { body } = await testClient
       .get("/api/v1/protected")
       .set("Cookie", [`session=${session.id}`])
       .expect(200);


### PR DESCRIPTION
Importing the supertest request often means having to write it manually as auto-imports don't tend to account for it for some reason. This changes that so that it is its own fixture instead and is exported by us, which makes importing it easier and may also be more futureproof in case we ever swap out supertest.

# Refactor

This is a change to the code layout of `lexicon`. It changes how the code is presented in terms of quality and structure without changing its overall user-facing behaviour or functionality.

Please see the commits tab of this pull request for the description of changes.
