### PR TITLE
Convert the object to an array exactly once

### DIFF
--- a/apps/back-end/src/utility/databaseFilters/fetchValue.ts
+++ b/apps/back-end/src/utility/databaseFilters/fetchValue.ts
@@ -11,17 +11,17 @@ async function fetchValue<ValueType>(
     return null;
   }
 
-  const columns = Object.keys(result).length;
+  const values = Object.values(result);
 
-  if (columns !== 1) {
+  if (values.length !== 1) {
     throw new DataError(
-      { columns },
+      { columns: values.length },
       "MULTIPLE_COLUMNS_ERROR",
       "Expected only one column to be returned",
     );
   }
 
-  return Object.values(result)[0];
+  return values[0];
 }
 
 export default fetchValue;


### PR DESCRIPTION
Previously we were converting the object to an array of keys just to get its length, and then converting to an array of values to get the first item. This changes that so that we only convert to an array of values once, and use both for the length and item return.

# Refactor

This is a change to the code layout of `lexicon`. It changes how the code is presented in terms of quality and structure without changing its overall user-facing behaviour or functionality.

Please see the commits tab of this pull request for the description of changes.
