### PR TITLE
Add fetchValues

### DIFF
--- a/apps/back-end/src/services/blogs/queryBlogIds.ts
+++ b/apps/back-end/src/services/blogs/queryBlogIds.ts
@@ -9,17 +9,13 @@ import z from "zod";
 import { blogsTable } from "src/database/schema";
 import buildBlogsQuery from "src/services/blogs/helpers/buildBlogsQuery";
 import extractRows from "src/utility/databaseFilters/extractRows";
-import fetchAll from "src/utility/databaseFilters/fetchAll";
+import fetchValues from "src/utility/databaseFilters/fetchValues";
 
 async function queryBlogIds(connection: Connection, filters: BlogFilter): Promise<Array<string>> {
-  const result = await fetchAll(
+  const ids = await fetchValues(
     extractRows(connection.execute(buildBlogsQuery(sql`${blogsTable.id}`, filters))),
   );
-  return az.with(z.array(z.uuid())).parse(
-    result.map((record) => {
-      return record.id;
-    }),
-  );
+  return az.with(z.array(z.uuid())).parse(ids);
 }
 
 export default queryBlogIds;

--- a/apps/back-end/src/utility/databaseFilters/fetchValues.ts
+++ b/apps/back-end/src/utility/databaseFilters/fetchValues.ts
@@ -1,0 +1,47 @@
+import { removeDuplicates } from "@alextheman/utility";
+import { DataError } from "@alextheman/utility/v6";
+
+async function fetchValues<ValueType>(
+  query: Promise<Array<Record<string, ValueType>>>,
+): Promise<Array<ValueType>> {
+  const results = await query;
+
+  if (results.length === 0) {
+    return [];
+  }
+
+  const columnNames = results.map((result) => {
+    const objectKeys = Object.keys(result);
+
+    if (objectKeys.length !== 1) {
+      throw new DataError(
+        { columns: objectKeys.length },
+        "MULTIPLE_COLUMNS_ERROR",
+        "Expected only one column to be returned",
+      );
+    }
+
+    return objectKeys[0];
+  });
+
+  const uniqueColumnNames = removeDuplicates(columnNames);
+
+  if (uniqueColumnNames.length !== 1) {
+    throw new DataError(
+      {
+        uniqueColumnNames,
+        uniqueColumnNamesCount: uniqueColumnNames.length,
+      },
+      "MULTIPLE_UNIQUE_COLUMN_NAMES",
+      "Expected each row to contain the same single column name.",
+    );
+  }
+
+  const [columnName] = uniqueColumnNames;
+
+  return results.map((result) => {
+    return result[columnName];
+  });
+}
+
+export default fetchValues;


### PR DESCRIPTION
This is particularly useful in cases where we have multiple rows but they all return a single value. A very common example is if we are getting an array of IDs.

# Refactor

This is a change to the code layout of `lexicon`. It changes how the code is presented in terms of quality and structure without changing its overall user-facing behaviour or functionality.

Please see the commits tab of this pull request for the description of changes.
