### PR TITLE
Add subtitleFormatter for use in QueryBoundary.Value in subtitle

### DIFF
--- a/apps/front-end/src/resources/Users/pages/UserProfile/index.tsx
+++ b/apps/front-end/src/resources/Users/pages/UserProfile/index.tsx
@@ -6,7 +6,6 @@ import {
 } from "@alextheman/components/DropdownMenu";
 import { InternalLink } from "@alextheman/components/routing";
 import { createTabGroup } from "@alextheman/components/Tab";
-import Typography from "@mui/material/Typography";
 
 import { useAuth } from "src/AuthContextProvider";
 import DropdownMenuIconButton from "src/components/DropdownIconButton";
@@ -14,6 +13,7 @@ import createObjectQueryBoundary from "src/groups/QueryBoundary/creators/createO
 import AboutUser from "src/resources/Users/pages/UserProfile/AboutUser";
 import UserBlogs from "src/resources/Users/pages/UserProfile/UserBlogs";
 import useUserQuery from "src/resources/Users/queries/useUserQuery";
+import subtitleFormatter from "src/utility/valueFormatters/subtitleFormatter";
 
 interface UserProfileProps {
   userId: string;
@@ -42,17 +42,7 @@ function UserProfile({ userId }: UserProfileProps) {
           }}
         </QueryBoundary.Data>
       }
-      subtitle={
-        <QueryBoundary.Value propertyName="username">
-          {(username) => {
-            return (
-              <Typography variant="body2" color="text.secondary">
-                {username}
-              </Typography>
-            );
-          }}
-        </QueryBoundary.Value>
-      }
+      subtitle={<QueryBoundary.Value propertyName="username" valueFormatter={subtitleFormatter} />}
       action={
         <QueryBoundary.Data>
           {(user) => {

--- a/apps/front-end/src/utility/valueFormatters/subtitleFormatter.tsx
+++ b/apps/front-end/src/utility/valueFormatters/subtitleFormatter.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react";
+
+import Typography from "@mui/material/Typography";
+
+function subtitleFormatter<ValueType extends ReactNode>(value: ValueType): ReactNode {
+  return (
+    <Typography variant="body2" color="text.secondary">
+      {value}
+    </Typography>
+  );
+}
+
+export default subtitleFormatter;


### PR DESCRIPTION
It is expected that we may frequently use QueryBoundary.Value in subtitles, hence why this formatter now exists.

# Refactor

This is a change to the code layout of `lexicon`. It changes how the code is presented in terms of quality and structure without changing its overall user-facing behaviour or functionality.

Please see the commits tab of this pull request for the description of changes.
