### PR TITLE
Return the ValueType exactly from fetchValue rather than allow it to …

### DIFF
--- a/apps/back-end/src/services/blogs/countBlogs.ts
+++ b/apps/back-end/src/services/blogs/countBlogs.ts
@@ -2,7 +2,7 @@ import type { BlogFilter } from "@lexicon/models";
 
 import type { Connection } from "src/database/connection";
 
-import { assertNotNull, az } from "@alextheman/utility";
+import { az } from "@alextheman/utility";
 import { sql } from "drizzle-orm";
 import z from "zod";
 
@@ -14,7 +14,6 @@ async function countBlogs(
   filters: Omit<BlogFilter, "pageNumber" | "pageSize" | "sortColumn" | "sortDirection">,
 ): Promise<number> {
   const count = await fetchValue(buildBlogsQuery(connection, { count: sql`COUNT(*)` }, filters));
-  assertNotNull(count);
   return az.with(z.coerce.number().int()).parse(count);
 }
 

--- a/apps/back-end/src/utility/databaseFilters/fetchSole.ts
+++ b/apps/back-end/src/utility/databaseFilters/fetchSole.ts
@@ -1,13 +1,20 @@
 import { DataError } from "@alextheman/utility/v6";
 
-async function fetchSole<ItemType>(query: Promise<Array<ItemType>>): Promise<ItemType | null> {
+interface FetchSoleOptions {
+  errorMessage?: string;
+}
+
+async function fetchSole<ItemType>(
+  query: Promise<Array<ItemType>>,
+  options?: FetchSoleOptions,
+): Promise<ItemType | null> {
   const results = await query;
 
   if (results.length > 1) {
     throw new DataError(
       { length: results.length },
       "MULTIPLE_ROWS_ERROR",
-      "Expected only one or zero rows to be returned.",
+      options?.errorMessage ?? "Expected only one or zero rows to be returned.",
     );
   }
 

--- a/apps/back-end/src/utility/databaseFilters/fetchValue.ts
+++ b/apps/back-end/src/utility/databaseFilters/fetchValue.ts
@@ -4,11 +4,12 @@ import fetchSole from "src/utility/databaseFilters/fetchSole";
 
 async function fetchValue<ValueType>(
   query: Promise<Array<Record<string, ValueType>>>,
-): Promise<ValueType | null> {
-  const result = await fetchSole(query);
+): Promise<ValueType> {
+  const errorMessage = "Expected exactly one row to be returned.";
+  const result = await fetchSole(query, { errorMessage });
 
   if (result === null) {
-    return null;
+    throw new DataError({ result }, "NO_ROWS_ERROR", errorMessage);
   }
 
   const values = Object.values(result);
@@ -17,7 +18,7 @@ async function fetchValue<ValueType>(
     throw new DataError(
       { columns: values.length },
       "MULTIPLE_COLUMNS_ERROR",
-      "Expected only one column to be returned",
+      "Expected only one column to be returned.",
     );
   }
 


### PR DESCRIPTION
…be nullable

Values can genuinely be null as well - a null return from fetchValue does not necessarily mean tbat no rows were returned. As such, I think it's better to just let fetchValue throw an error on no rows returned (it wouldn't make sense without a row returned anyway) and return the value from that exact row.

# Refactor

This is a change to the code layout of `lexicon`. It changes how the code is presented in terms of quality and structure without changing its overall user-facing behaviour or functionality.

Please see the commits tab of this pull request for the description of changes.
