### PR TITLE
Fix auth redirect

### DIFF
--- a/apps/front-end/src/components/UserDropdown.tsx
+++ b/apps/front-end/src/components/UserDropdown.tsx
@@ -60,7 +60,7 @@ function UserDropdown() {
       nullFallback={
         <Button
           component={ExternalLink}
-          href={`${import.meta.env.VITE_API_BASE_URL}/api/v1/auth/google?redirect=${encodeURIComponent(window.location.origin)}`}
+          href={`/api/v1/auth/google?redirect=${encodeURIComponent(window.location.origin)}`}
         >
           Sign in
         </Button>


### PR DESCRIPTION
The VITE_API_BASE_URL environment variable is no longer needed.

# Bug Fix

This is a bug fix for `lexicon`. It fixes an unintended side-effect of the app.

Please see the commits tab of this pull request for the description of changes.
