### PR TITLE
Change the deployment order

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,88 +6,11 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-projects:
-    runs-on: ubuntu-latest
-    if: ${{ github.repository == 'alextheman231/lexicon' }}
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout the repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Install PNPM
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        with:
-          run_install: false
-
-      - name: Install Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 22
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Build packages
-        run: pnpm run build
-
-      - name: Save build cache
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: "**/.turbo"
-          key: deployment-build-${{ github.sha }}
-
-  deploy-database:
-    runs-on: ubuntu-latest
-    if: ${{ github.repository == 'alextheman231/lexicon' }}
-    needs: [build-projects]
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout the repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Install PNPM
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        with:
-          run_install: false
-
-      - name: Install Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 22
-          cache: "pnpm"
-
-      - name: Restore build cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: "**/.turbo"
-          key: deployment-build-${{ github.sha }}
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Build packages
-        run: pnpm run build
-
-      - name: Apply migrations
-        working-directory: apps/back-end
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          NODE_ENV: production
-        run: pnpm run migrate-db
-
   deploy-image:
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'alextheman231/lexicon' }}
     permissions:
       contents: read
-    needs: [deploy-database]
     steps:
       - name: Checkout the repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -112,26 +35,9 @@ jobs:
     if: ${{ github.repository == 'alextheman231/lexicon' }}
     permissions:
       contents: read
-    needs: [deploy-image]
-
-    steps:
-      - name: Install Render CLI
-        run: curl -fsSL https://raw.githubusercontent.com/render-oss/cli/refs/heads/main/bin/install.sh | sh
-
-      - name: Deploy back-end server to Render
-        env:
-          RENDER_API_KEY: ${{ secrets.RENDER_DEPLOY_KEY }}
-          RENDER_SERVICE_ID: ${{ vars.RENDER_SERVICE_ID }}
-        run: render deploys create $RENDER_SERVICE_ID --wait --confirm
-
-  deploy-sentry:
-    runs-on: ubuntu-latest
-    if: ${{ github.repository == 'alextheman231/lexicon' }}
-    permissions:
-      contents: read
-    needs: [deploy-app]
     env:
       SENTRY_RELEASE: ${{ github.sha }}
+    needs: [deploy-image]
     steps:
       - name: Checkout the repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -149,17 +55,34 @@ jobs:
           node-version: 22
           cache: "pnpm"
 
-      - name: Restore build cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Cache Turborepo cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: "**/.turbo"
-          key: deployment-build-${{ github.sha }}
+          key: turbo-deploy-${{ hashFiles('{apps,packages}/**', 'package.json', 'pnpm-lock.yaml', 'pnpm-workspace.yaml', 'turbo.json') }}
+          restore-keys: turbo-deploy-
 
       - name: Install dependencies
         run: pnpm install
 
+      - name: Install Render CLI
+        run: curl -fsSL https://raw.githubusercontent.com/render-oss/cli/refs/heads/main/bin/install.sh | sh
+
       - name: Build packages
         run: pnpm run build
+
+      - name: Deploy to Render
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_DEPLOY_KEY }}
+          RENDER_SERVICE_ID: ${{ vars.RENDER_SERVICE_ID }}
+        run: render deploys create $RENDER_SERVICE_ID --wait --confirm
+
+      - name: Apply migrations
+        working-directory: apps/back-end
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          NODE_ENV: production
+        run: pnpm run migrate-db
 
       - name: Create Sentry release for back-end
         uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528 # v3.7.0


### PR DESCRIPTION
Previously, the very first thing we did was database migrations, meaning that production had new migrations despite the newest app not being ready. This changes that so that database migrations happen immediately after app deployment, which is better because this step is often quick so production will be less out-of-sync. The separate build workflow has also been removed as it didn't buy us much - I think it's better to just do all steps that need the build context within the same job, especially given they aren't parallelisable.

# Miscellaneous

This is a general change to `lexicon` that does not fit in any of the other provided categories.

Please see the commits tab of this pull request for the description of changes.
